### PR TITLE
feat: Update login page images

### DIFF
--- a/login.css
+++ b/login.css
@@ -161,9 +161,9 @@ body {
 }
 
 .login-hero.individual {
-  background: url('images/family.jpg') center/cover no-repeat;
+  background: url('https://raw.githubusercontent.com/marialorena76/dashboard/main/images/imagen%20blanca.png') center/cover no-repeat;
 }
 
 .login-hero.business {
-  background: url('images/team.jpg') center/cover no-repeat;
+  background: url('https://raw.githubusercontent.com/marialorena76/dashboard/main/images/Imagen%20rosa.png') center/cover no-repeat;
 }


### PR DESCRIPTION
Change the background images for the individual and business login pages.

The new images are sourced from an external GitHub repository as per the user's request.
- Individual login page now uses 'imagen blanca.png'.
- Business login page now uses 'Imagen rosa.png'.