### PR TITLE
Add individual dashboard and profile page

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -1,0 +1,260 @@
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: #f5f5f5;
+  color: #163c30;
+}
+.dashboard {
+  display: flex;
+  min-height: 100vh;
+}
+.sidebar {
+  width: 260px;
+  background: #d7b56d url('images/office-meeting.jpg') center/cover no-repeat;
+  color: #163c30;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1rem;
+  position: relative;
+}
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(215, 181, 109, 0.9);
+}
+.sidebar > * {
+  position: relative;
+}
+.profile {
+  text-align: center;
+}
+.profile img {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.menu a {
+  display: block;
+  color: #163c30;
+  text-decoration: none;
+  padding: 0.5rem 0;
+  font-weight: 600;
+}
+.sidebar-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.logout {
+  background: #163c30;
+  color: #fff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+.lang button {
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #163c30;
+  background: transparent;
+  cursor: pointer;
+}
+.main-content {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.hero-top {
+  background: url('images/flying-kite.jpg') center/cover no-repeat;
+  border-radius: 8px;
+  min-height: 140px;
+}
+.welcome {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+.status-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.status-cards .card {
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 8px;
+  flex: 1;
+  min-width: 150px;
+}
+.status-cards .active {
+  color: #2e7d32;
+  font-weight: 700;
+}
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+.actions button {
+  background: #163c30;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+.promo {
+  background: url('images/white-flowers.jpg') center/cover no-repeat;
+  border-radius: 8px;
+  padding: 2rem;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  min-height: 160px;
+}
+.promo-text h2 {
+  margin: 0 0 0.5rem 0;
+}
+/* Additional styles for My Profile page */
+.menu a.active {
+  font-weight: 700;
+}
+
+.breadcrumb {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.section-card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-card h2 {
+  margin-top: 0;
+}
+
+.section-card button {
+  background: #163c30;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.personal-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.personal-info img {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+
+.identification-documents .doc-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.identification-documents .doc-item .status {
+  margin-left: auto;
+  font-weight: 600;
+  color: #c62828;
+}
+
+.identification-documents .doc-item .status.uploaded {
+  color: #2e7d32;
+}
+
+.identification-documents .doc-item:last-child {
+  margin-bottom: 0;
+}
+
+.language-preference .language-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.language-preference .language-row select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+/* Form styles for My Profile personal details */
+.personal-info-form {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.personal-info-form img {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.personal-info-form form {
+  flex: 1;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.form-group {
+  flex: 1;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.form-group input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.form-actions .cancel {
+  background: #ccc;
+  color: #163c30;
+}

--- a/individual-dashboard.html
+++ b/individual-dashboard.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard - Individual</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <div class="dashboard">
+    <aside class="sidebar">
+      <div class="profile">
+        <img src="images/flying-kite.jpg" alt="Profile picture">
+        <h2>Maria Thompson</h2>
+        <p>Welcome to your Dashboard</p>
+      </div>
+      <nav class="menu">
+        <a href="#">My Account</a>
+        <a href="#">Payments</a>
+        <a href="#">Help</a>
+        <a href="#">Settings</a>
+      </nav>
+      <div class="sidebar-bottom">
+        <button class="logout">Log Out</button>
+        <div class="lang">
+          <button>English</button>
+          <button>Español</button>
+        </div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <section class="hero-top"></section>
+      <section class="welcome">
+        <h1>Welcome back, Maria</h1>
+        <div class="status-cards">
+          <div class="card">
+            <h3>Your Plan Status</h3>
+            <p class="active">ACTIVE</p>
+          </div>
+          <div class="card">
+            <h3>Your Coverage</h3>
+            <p>Up to $100,000</p>
+          </div>
+          <div class="card">
+            <h3>Next Payment</h3>
+            <p>Due Oct 15, 2025</p>
+          </div>
+        </div>
+        <div class="actions">
+          <button>Update My Profile</button>
+          <button>Manage My Plan</button>
+          <button>Add a Family Member</button>
+          <button>Manage Alerts</button>
+        </div>
+      </section>
+      <section class="promo">
+        <div class="promo-text">
+          <h2>Human-centered benefits for your team.</h2>
+          <p>&copy;2025 MallowCare | Privacy Policy</p>
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/my-profile.html
+++ b/my-profile.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard - My Profile</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <div class="dashboard">
+    <aside class="sidebar">
+      <div class="profile">
+        <img src="images/flying-kite.jpg" alt="Profile picture">
+        <h2>Maria Thompson</h2>
+        <p>Welcome to your Dashboard</p>
+      </div>
+      <nav class="menu">
+        <a href="#" class="active">My Account</a>
+        <a href="#">Payments</a>
+        <a href="#">Help</a>
+        <a href="#">Settings</a>
+      </nav>
+      <div class="sidebar-bottom">
+        <button class="logout">Log Out</button>
+        <div class="lang">
+          <button>English</button>
+          <button>Español</button>
+        </div>
+      </div>
+    </aside>
+    <main class="main-content">
+      <div class="breadcrumb">Dashboard - My Account - My Profile</div>
+      <h1>My Profile</h1>
+
+      <section class="section-card personal-details">
+        <h2>Personal Details</h2>
+        <p>View or edit your personal info and account details.</p>
+        <div class="personal-info-form">
+          <img src="images/imagen blanca.png" alt="Profile icon">
+          <form id="personalForm">
+            <div class="form-row">
+              <div class="form-group">
+                <label for="firstName">First Name</label>
+                <input type="text" id="firstName" name="firstName" value="Maria">
+              </div>
+              <div class="form-group">
+                <label for="lastName">Last Name</label>
+                <input type="text" id="lastName" name="lastName" value="Thompson">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group">
+                <label for="email">Email Address</label>
+                <input type="email" id="email" name="email" value="maria@gmail.com">
+              </div>
+              <div class="form-group">
+                <label for="phone">Phone Number</label>
+                <input type="tel" id="phone" name="phone" value="123-123-4567">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group">
+                <label for="address1">Address Line 1</label>
+                <input type="text" id="address1" name="address1" value="123 Main Street">
+              </div>
+              <div class="form-group">
+                <label for="address2">Address Line 2</label>
+                <input type="text" id="address2" name="address2">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group">
+                <label for="city">City</label>
+                <input type="text" id="city" name="city" value="Miami">
+              </div>
+              <div class="form-group">
+                <label for="state">State</label>
+                <input type="text" id="state" name="state" value="FL">
+              </div>
+              <div class="form-group">
+                <label for="postal">Postal Code</label>
+                <input type="text" id="postal" name="postal" value="33101">
+              </div>
+            </div>
+            <div class="form-actions">
+              <button type="button" id="cancelBtn" class="cancel">Cancel</button>
+              <button type="submit">Save Changes</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="section-card identification-documents">
+        <h2>Identification Documents</h2>
+        <div class="doc-item">
+          <span>Passport</span>
+          <span class="status uploaded">UPLOADED</span>
+          <button>Upload/Update Document</button>
+        </div>
+        <div class="doc-item">
+          <span>Driver's License</span>
+          <span class="status uploaded">UPLOADED</span>
+          <button>Upload/Update Document</button>
+        </div>
+        <div class="doc-item">
+          <span>Social Security</span>
+          <span class="status">PENDING</span>
+          <button>Upload/Update Document</button>
+        </div>
+      </section>
+
+      <section class="section-card language-preference">
+        <h2>Language Preference</h2>
+        <div class="language-row">
+          <select id="languageSelect">
+            <option value="en">English</option>
+            <option value="es">Español</option>
+          </select>
+          <button id="updateLang">Update Language</button>
+        </div>
+      </section>
+    </main>
+  </div>
+  <script src="profile.js"></script>
+</body>
+</html>

--- a/profile.js
+++ b/profile.js
@@ -1,0 +1,40 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('personalForm');
+  const cancelBtn = document.getElementById('cancelBtn');
+  const inputs = form.querySelectorAll('input');
+  const languageSelect = document.getElementById('languageSelect');
+  const updateLangBtn = document.getElementById('updateLang');
+
+  // Load saved values if available
+  const saved = JSON.parse(localStorage.getItem('personalDetails') || '{}');
+  inputs.forEach(input => {
+    if (saved[input.name]) {
+      input.value = saved[input.name];
+    }
+    input.defaultValue = input.value;
+  });
+
+  cancelBtn.addEventListener('click', () => {
+    form.reset();
+  });
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const data = {};
+    inputs.forEach(input => {
+      data[input.name] = input.value;
+      input.defaultValue = input.value;
+    });
+    localStorage.setItem('personalDetails', JSON.stringify(data));
+    alert('Changes saved');
+  });
+
+  // Language preference
+  const savedLang = localStorage.getItem('language') || 'en';
+  languageSelect.value = savedLang;
+
+  updateLangBtn.addEventListener('click', () => {
+    localStorage.setItem('language', languageSelect.value);
+    alert('Language updated');
+  });
+});


### PR DESCRIPTION
## Summary
- create dashboard page for individual users with sidebar, status cards, and actions
- add My Profile page with editable personal details form, document status, and language selection
- extend dashboard styles for profile layout and active menu highlighting

## Testing
- `npm test` (fails: enoent Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b6be95d9e0832798f309504ac19d58