### PR TITLE
Create polished individual profile dashboard

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -1,310 +1,249 @@
+:root {
+  --color-forest-900: #163c30;
+  --color-forest-800: #124032;
+  --color-forest-700: #1f5748;
+  --color-forest-100: #e5ebe8;
+  --color-gold-200: #f4e2bc;
+  --color-gold-100: #fbf5e7;
+  --color-background: #f6f8f7;
+  --color-muted: #556a61;
+  --radius-large: 24px;
+  --radius-medium: 16px;
+  --shadow-card: 0 24px 40px rgba(17, 40, 32, 0.12);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  background: #f5f5f5;
-  color: #163c30;
+  background: var(--color-background);
+  color: var(--color-forest-900);
+  line-height: 1.55;
 }
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+}
+
 .dashboard {
-  display: flex;
   min-height: 100vh;
+  display: flex;
+  background: var(--color-background);
 }
+
 .sidebar {
-  width: 260px;
-  background: #d7b56d url('images/office-meeting.jpg') center/cover no-repeat;
-  color: #163c30;
+  width: 280px;
+  background: linear-gradient(180deg, #d8b86a 0%, #f5e6c7 100%);
+  color: var(--color-forest-900);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  padding: 1rem;
-  position: relative;
+  justify-content: flex-start;
+  gap: 2rem;
+  padding: 2.5rem 2rem;
+  box-shadow: inset -1px 0 0 rgba(22, 60, 48, 0.12);
 }
-.sidebar::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(215, 181, 109, 0.9);
-}
-.sidebar > * {
-  position: relative;
-}
+
 .profile {
   text-align: center;
 }
+
 .profile img {
-  width: 80px;
-  height: 80px;
+  width: 96px;
+  height: 96px;
   border-radius: 50%;
   object-fit: cover;
+  margin: 0 auto;
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 10px 20px rgba(17, 40, 32, 0.18);
 }
-.menu a {
-  display: block;
-  color: #163c30;
-  text-decoration: none;
-  padding: 0.5rem 0;
-  font-weight: 600;
+
+.profile h2 {
+  margin: 1.25rem 0 0.35rem;
+  font-size: 1.3rem;
+  font-weight: 700;
 }
-.sidebar-bottom {
+
+.profile p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.menu {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
+
+.menu a {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.menu a:hover {
+  background: rgba(22, 60, 48, 0.12);
+}
+
+.menu a.active {
+  background: var(--color-forest-900);
+  color: #fdf9ed;
+}
+
+.sidebar-bottom {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .logout {
-  background: #163c30;
+  background: var(--color-forest-900);
   color: #fff;
   border: none;
-  padding: 0.5rem;
-  border-radius: 4px;
-  cursor: pointer;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
   font-weight: 600;
-}
-.lang button {
-  margin-right: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  border: 1px solid #163c30;
-  background: transparent;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
+
+.logout:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(17, 40, 32, 0.2);
+}
+
+.lang {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.lang button {
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(22, 60, 48, 0.25);
+  background: transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.lang button:hover,
+.lang button.active {
+  background: rgba(22, 60, 48, 0.12);
+}
+
 .main-content {
   flex: 1;
-  padding: 2rem;
+  padding: 3rem clamp(2rem, 6vw, 4rem);
   display: flex;
   flex-direction: column;
   gap: 2rem;
 }
-.hero-top {
-  background: url('images/flying-kite.jpg') center/cover no-repeat;
-  border-radius: 8px;
-  min-height: 140px;
-}
-.welcome {
-  background: #fff;
-  border-radius: 8px;
-  padding: 1.5rem;
-}
-.status-cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 1rem;
-}
-.status-cards .card {
-  background: #f5f5f5;
-  padding: 1rem;
-  border-radius: 8px;
-  flex: 1;
-  min-width: 150px;
-}
-.status-cards .active {
-  color: #2e7d32;
-  font-weight: 700;
-}
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 1.5rem;
-}
-.actions button {
-  background: #163c30;
-  color: #fff;
-  border: none;
-  padding: 0.75rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 600;
-}
-.promo {
-  background: url('images/white-flowers.jpg') center/cover no-repeat;
-  border-radius: 8px;
-  padding: 2rem;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  min-height: 160px;
-}
-.promo-text h2 {
-  margin: 0 0 0.5rem 0;
-}
-codex/add-images-and-create-user-dashboard-v85he0
 
-codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
-codex/add-images-and-create-user-dashboard-heebri
-codex/add-images-and-create-user-dashboard-ligup1
-codex/add-images-and-create-user-dashboard-31fdkc
-main
-main
-main
-main
- main
-/* Additional styles for My Profile page */
-.menu a.active {
-  font-weight: 700;
+.main-content h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
 }
 
 .breadcrumb {
-  font-size: 0.875rem;
-  color: #555;
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .section-card {
   background: #fff;
-  border-radius: 8px;
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
+  border-radius: var(--radius-medium);
+  padding: 1.75rem;
+  box-shadow: 0 18px 35px rgba(17, 40, 32, 0.08);
 }
 
 .section-card h2 {
   margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.section-card p {
+  color: var(--color-muted);
 }
 
 .section-card button {
-  background: #163c30;
+  background: var(--color-forest-900);
   color: #fff;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  padding: 0.6rem 1.35rem;
+  border-radius: 999px;
+  font-weight: 600;
   cursor: pointer;
-  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.personal-info {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 1rem;
+.section-card button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(17, 40, 32, 0.18);
 }
 
-.personal-info img {
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
-  object-fit: cover;
+.section-card .cancel {
+  background: var(--color-forest-100);
+  color: var(--color-forest-900);
 }
 
- codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
-coex/add-images-and-create-user-dashboard-heebri
-coex/add-images-and-create-user-dashboard-ligup1
-main
- main
- main
- main
-
-.identification-documents .doc-item {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.identification-documents .doc-item .status {
-  margin-left: auto;
-  font-weight: 600;
-  color: #c62828;
-}
-
-.identification-documents .doc-item .status.uploaded {
-  color: #2e7d32;
-}
-
-codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
-codex/add-images-and-create-user-dashboard-heebri
-
-.identification-documents .doc-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-main
-main
- main
- main
-main
-.identification-documents .doc-item:last-child {
-  margin-bottom: 0;
-}
-
-.language-preference .language-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
- codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
-codex/add-images-and-create-user-dashboard-heebri
-
-codex/add-images-and-create-user-dashboard-ligup1
-main
- main
- main
- main
-
-.language-preference .language-row select {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-
-/* Form styles for My Profile personal details */
-.personal-info-form {
-  display: flex;
-  align-items: flex-start;
-  gap: 2rem;
-  margin-top: 1rem;
-}
-
-.personal-info-form img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.personal-info-form form {
-  flex: 1;
+.section-card .danger {
+  background: #c62828;
 }
 
 .form-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 1.5rem;
+  margin-bottom: 1.25rem;
 }
 
 .form-group {
   flex: 1;
-  min-width: 120px;
+  min-width: 200px;
   display: flex;
   flex-direction: column;
+  gap: 0.35rem;
 }
 
 .form-group label {
   font-weight: 600;
-  margin-bottom: 0.25rem;
+  color: var(--color-forest-900);
 }
 
-.form-group input {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+.form-group input,
+.form-group select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(22, 60, 48, 0.18);
+  background: #fff;
+  font-size: 1rem;
+  color: inherit;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: 2px solid rgba(31, 87, 72, 0.25);
 }
 
 .form-actions {
@@ -313,92 +252,114 @@ main
   gap: 1rem;
 }
 
-.form-actions .cancel {
-  background: #ccc;
-  color: #163c30;
-}
- codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
-codex/add-images-and-create-user-dashboard-heebri
- main
- main
-
-/* Protected Members styles */
-.members-table .table-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-.members-table table {
+/* Tables */
+table {
   width: 100%;
   border-collapse: collapse;
 }
-.members-table th,
-.members-table td {
+
+th,
+td {
   text-align: left;
-  padding: 0.75rem;
-  border-bottom: 1px solid #ddd;
+  padding: 0.85rem 0.75rem;
+  border-bottom: 1px solid rgba(22, 60, 48, 0.12);
 }
-.members-table th {
-  background: #f5f5f5;
+
+th {
+  background: rgba(22, 60, 48, 0.05);
+  font-weight: 600;
 }
-.members-table button {
-  background: #163c30;
+
+/* Members */
+.members-table .table-header,
+.payment-history .table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.members-table button,
+.payment-history button,
+.plan-type .plan-row button,
+.plan-overview button,
+.settings-section .option-row button {
+  background: var(--color-forest-900);
   color: #fff;
   border: none;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
   cursor: pointer;
-  font-size: 0.875rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
-.members-table .delete-btn {
+
+.members-table button:hover,
+.payment-history button:hover,
+.plan-type .plan-row button:hover,
+.plan-overview button:hover,
+.settings-section .option-row button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(17, 40, 32, 0.18);
+}
+
+.members-table .delete-btn,
+.payment-history .delete-btn,
+.plan-type .plan-row .expire-btn,
+.settings-section .option-row .danger {
   background: #c62828;
 }
-.form-group select {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+
+.payment-history input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(22, 60, 48, 0.18);
+  background: #fff;
 }
-.form-actions .danger {
-  background: #c62828;
+
+.payment-history .status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  background: rgba(22, 60, 48, 0.1);
+  color: var(--color-forest-900);
 }
 
- codex/add-images-and-create-user-dashboard-v85he0
+.payment-history .status.paid {
+  background: #c8e6c9;
+  color: #2e7d32;
+}
 
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
- main
- main
-/* Manage My Plan styles */
+/* Manage Plan */
 .plan-overview .plan-row,
 .plan-type .plan-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   margin-bottom: 1rem;
 }
 
 .plan-overview .status {
-  background: #c8e6c9;
-  color: #2e7d32;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-weight: 600;
+  background: #e4f3e8;
+  color: #1a7f52;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 700;
 }
 
 .plan-overview .status.expired {
-  background: #ffcdd2;
+  background: #fde1e1;
   color: #c62828;
 }
 
 .plan-overview button {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
 }
 
 .plan-type .plan-grid {
@@ -408,85 +369,23 @@ codex/add-images-and-create-user-dashboard-heebri
 }
 
 .plan-type h3 {
-  margin-top: 0;
+  margin: 0 0 1rem;
 }
 
-.plan-type .plan-row button {
-  background: #163c30;
-  color: #fff;
-  border: none;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.plan-type .plan-row .expire-btn {
-  background: #c62828;
-}
-
- codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
- main
-/* Payments styles */
-.payment-history .table-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-.payment-history input {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
-.payment-history table {
-  width: 100%;
-  border-collapse: collapse;
-}
-.payment-history th,
-.payment-history td {
-  text-align: left;
-  padding: 0.75rem;
-  border-bottom: 1px solid #ddd;
-}
-.payment-history th {
-  background: #f5f5f5;
-}
-.payment-history .status {
-  display: inline-block;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-weight: 600;
-}
-.payment-history .status.paid {
-  background: #c8e6c9;
-  color: #2e7d32;
-}
-.payment-history button {
-  background: #163c30;
-  color: #fff;
-  border: none;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.875rem;
-}
- codex/add-images-and-create-user-dashboard-v85he0
-/* Settings page styles */
+/* Settings */
 .settings-section .option-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   margin-bottom: 1rem;
 }
 
 .switch {
   position: relative;
   display: inline-block;
-  width: 40px;
-  height: 20px;
+  width: 44px;
+  height: 22px;
 }
 
 .switch input {
@@ -498,20 +397,17 @@ codex/add-images-and-create-user-dashboard-heebri
 .slider {
   position: absolute;
   cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: #ccc;
+  inset: 0;
+  background: #cfd8d3;
   transition: 0.4s;
-  border-radius: 20px;
+  border-radius: 999px;
 }
 
 .slider:before {
   position: absolute;
   content: "";
-  height: 16px;
-  width: 16px;
+  height: 18px;
+  width: 18px;
   left: 2px;
   bottom: 2px;
   background: #fff;
@@ -520,32 +416,242 @@ codex/add-images-and-create-user-dashboard-heebri
 }
 
 .switch input:checked + .slider {
-  background: #163c30;
+  background: var(--color-forest-900);
 }
 
 .switch input:checked + .slider:before {
-  transform: translateX(20px);
+  transform: translateX(22px);
 }
 
-.settings-section .option-row button {
-  background: #163c30;
+/* Profile overview */
+.profile-main {
+  background: var(--color-background);
+}
+
+.profile-wrapper {
+  max-width: 1000px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.profile-summary {
+  background: #fff;
+  border-radius: var(--radius-large);
+  padding: clamp(2rem, 3vw, 3rem);
+  box-shadow: var(--shadow-card);
+}
+
+.profile-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  margin: 0 0 0.75rem;
+}
+
+.profile-summary h1 {
+  margin: 0 0 2rem;
+}
+
+.status-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.status-card {
+  background: var(--color-gold-100);
+  border-radius: var(--radius-medium);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status-card .label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-card .value {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.status-card .status-active {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: #e4f3e8;
+  color: #1a7f52;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+}
+
+.action-grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  background: var(--color-forest-900);
+  color: #fff;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(17, 40, 32, 0.18);
+}
+
+.benefits-banner {
+  background: linear-gradient(120deg, #1f4f41 0%, #0f3328 100%);
+  border-radius: var(--radius-large);
+  padding: clamp(2rem, 3vw, 3rem);
+  color: #f5fbf8;
+  box-shadow: 0 30px 50px rgba(12, 35, 28, 0.35);
+}
+
+.benefits-banner h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.benefits-banner p {
+  margin-bottom: 0.5rem;
+  max-width: 540px;
+}
+
+.banner-meta {
+  font-size: 0.85rem;
+  color: rgba(245, 251, 248, 0.75);
+}
+
+/* Hero layout for legacy dashboard */
+.hero-top {
+  background: url('images/flying-kite.jpg') center/cover no-repeat;
+  border-radius: var(--radius-medium);
+  min-height: 140px;
+}
+
+.welcome {
+  background: #fff;
+  border-radius: var(--radius-medium);
+  padding: 1.75rem;
+  box-shadow: 0 18px 35px rgba(17, 40, 32, 0.08);
+}
+
+.status-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.status-cards .card {
+  background: var(--color-gold-100);
+  padding: 1rem;
+  border-radius: var(--radius-medium);
+  flex: 1;
+  min-width: 180px;
+}
+
+.status-cards .active {
+  color: #1a7f52;
+  font-weight: 700;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.actions button {
+  background: var(--color-forest-900);
   color: #fff;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
   font-weight: 600;
+  cursor: pointer;
 }
 
-.settings-section .option-row .danger {
-  background: #c62828;
+.promo {
+  background: url('images/white-flowers.jpg') center/cover no-repeat;
+  border-radius: var(--radius-medium);
+  padding: 2rem;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  min-height: 160px;
+  box-shadow: 0 20px 40px rgba(17, 40, 32, 0.22);
 }
 
+/* Responsive tweaks */
+@media (max-width: 1024px) {
+  .dashboard {
+    flex-direction: column;
+  }
 
+  .sidebar {
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
 
-main
-main
-main
- main
- main
- main
+  .menu {
+    width: 100%;
+    align-items: center;
+  }
+
+  .menu a {
+    width: 100%;
+  }
+
+  .sidebar-bottom {
+    width: 100%;
+    align-items: center;
+  }
+
+  .main-content {
+    padding: 2.5rem 1.75rem 3rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .form-row {
+    flex-direction: column;
+  }
+
+  .members-table .table-header,
+  .payment-history .table-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .actions,
+  .status-cards {
+    flex-direction: column;
+  }
+}

--- a/my-profile.html
+++ b/my-profile.html
@@ -6,280 +6,68 @@
   <title>Dashboard - My Profile</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="dashboard.css">
 </head>
 <body>
-  <div class="dashboard">
+  <div class="dashboard profile-dashboard">
     <aside class="sidebar">
       <div class="profile">
-        <img src="images/flying-kite.jpg" alt="Profile picture">
+        <img src="images/flying-kite.jpg" alt="Portrait of Maria Thompson">
         <h2>Maria Thompson</h2>
         <p>Welcome to your Dashboard</p>
       </div>
       <nav class="menu">
-codex/add-images-and-create-user-dashboard-v85he0
         <a href="my-profile.html" class="active">My Account</a>
         <a href="payments.html">Payments</a>
-        <a href="#">Help</a>
+        <a href="manage-my-plan.html">Manage My Plan</a>
         <a href="settings.html">Settings</a>
-
- codex/add-images-and-create-user-dashboard-vak73b
-        <a href="my-profile.html" class="active">My Account</a>
-        <a href="payments.html">Payments</a>
-
-        <a href="#" class="active">My Account</a>
-        <a href="#">Payments</a>
- main
-        <a href="#">Help</a>
-        <a href="#">Settings</a>
- main
       </nav>
       <div class="sidebar-bottom">
         <button class="logout">Log Out</button>
         <div class="lang">
-          <button>English</button>
+          <button class="active">English</button>
           <button>Español</button>
         </div>
       </div>
     </aside>
-    <main class="main-content">
-      <div class="breadcrumb">Dashboard - My Account - My Profile</div>
-      <h1>My Profile</h1>
-
-      <section class="section-card personal-details">
- codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
-codex/add-images-and-create-user-dashboard-heebri
-
-codex/add-images-and-create-user-dashboard-ligup1
- main
-main
- main
- main
-        <h2>Personal Details</h2>
-        <p>View or edit your personal info and account details.</p>
-        <div class="personal-info-form">
-          <img src="images/imagen blanca.png" alt="Profile icon">
-          <form id="personalForm">
-            <div class="form-row">
-              <div class="form-group">
-                <label for="firstName">First Name</label>
-                <input type="text" id="firstName" name="firstName" value="Maria">
-              </div>
-              <div class="form-group">
-                <label for="lastName">Last Name</label>
-                <input type="text" id="lastName" name="lastName" value="Thompson">
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group">
-                <label for="email">Email Address</label>
-                <input type="email" id="email" name="email" value="maria@gmail.com">
-              </div>
-              <div class="form-group">
-                <label for="phone">Phone Number</label>
-                <input type="tel" id="phone" name="phone" value="123-123-4567">
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group">
-                <label for="address1">Address Line 1</label>
-                <input type="text" id="address1" name="address1" value="123 Main Street">
-              </div>
-              <div class="form-group">
-                <label for="address2">Address Line 2</label>
-                <input type="text" id="address2" name="address2">
-              </div>
-            </div>
-            <div class="form-row">
-              <div class="form-group">
-                <label for="city">City</label>
-                <input type="text" id="city" name="city" value="Miami">
-              </div>
-              <div class="form-group">
-                <label for="state">State</label>
-                <input type="text" id="state" name="state" value="FL">
-              </div>
-              <div class="form-group">
-                <label for="postal">Postal Code</label>
-                <input type="text" id="postal" name="postal" value="33101">
-              </div>
-            </div>
-            <div class="form-actions">
-              <button type="button" id="cancelBtn" class="cancel">Cancel</button>
-              <button type="submit">Save Changes</button>
-            </div>
-          </form>
- codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
-codex/add-images-and-create-user-dashboard-iq4qsb
-
- codex/add-images-and-create-user-dashboard-heebri
-
-
-        <div class="section-header" style="display:flex; justify-content:space-between; align-items:center;">
-          <div>
-            <h2>Personal Details</h2>
-            <p>View or edit your personal info and account details.</p>
+    <main class="main-content profile-main">
+      <div class="profile-wrapper">
+        <section class="profile-summary">
+          <p class="profile-eyebrow">My Account Overview</p>
+          <h1>Welcome back, Maria</h1>
+          <div class="status-grid">
+            <article class="status-card">
+              <span class="label">Your Plan Status</span>
+              <span class="value status-active">ACTIVE</span>
+            </article>
+            <article class="status-card">
+              <span class="label">Your Coverage</span>
+              <span class="value">Up to $100,000</span>
+            </article>
+            <article class="status-card">
+              <span class="label">Next Payment</span>
+              <span class="value">$498.00 due Sep 15, 2025</span>
+            </article>
           </div>
-          <button>Edit Details</button>
-        </div>
-        <div class="personal-info">
-          <img src="images/imagen blanca.png" alt="Profile icon">
-          <div class="info">
-            <p>Maria Thompson</p>
-            <p>maria@gmail.com</p>
-            <p>123-123-4567</p>
-            <p>123 Main Street, Miami, FL</p>
+          <div class="action-grid">
+            <a class="action-button" href="settings.html">Update My Profile</a>
+            <a class="action-button" href="manage-my-plan.html">Manage My Plan</a>
+            <a class="action-button" href="protected-members.html">Add a Family Member</a>
+            <a class="action-button" href="#">Manage Alerts</a>
           </div>
-main
-main
- main
- main
- main
-        </div>
-      </section>
+        </section>
 
-      <section class="section-card identification-documents">
-        <h2>Identification Documents</h2>
-        <div class="doc-item">
-          <span>Passport</span>
- codex/add-images-and-create-user-dashboard-v85he0
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-vak73b
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-heebri
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-ligup1
-          <span class="status uploaded">UPLOADED</span>
-
- main
- main
- main
- main
- main
-          <button>Upload/Update Document</button>
-        </div>
-        <div class="doc-item">
-          <span>Driver's License</span>
-codex/add-images-and-create-user-dashboard-v85he0
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-vak73b
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-          <span class="status uploaded">UPLOADED</span>
-
- codex/add-images-and-create-user-dashboard-heebri
-          <span class="status uploaded">UPLOADED</span>
- codex/add-images-and-create-user-dashboard-ligup1
-          <span class="status uploaded">UPLOADED</span>
- main
-main
- main
-main
-main
-          <button>Upload/Update Document</button>
-        </div>
-        <div class="doc-item">
-          <span>Social Security</span>
-codex/add-images-and-create-user-dashboard-v85he0
-          <span class="status">PENDING</span>
-
- codex/add-images-and-create-user-dashboard-vak73b
-          <span class="status">PENDING</span>
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-          <span class="status">PENDING</span>
-
- codex/add-images-and-create-user-dashboard-heebri
-          <span class="status">PENDING</span>
-
- codex/add-images-and-create-user-dashboard-ligup1
-          <span class="status">PENDING</span>
-
- main
- main
- main
- main
- main
-          <button>Upload/Update Document</button>
-        </div>
-      </section>
-
-      <section class="section-card language-preference">
-        <h2>Language Preference</h2>
-        <div class="language-row">
-codex/add-images-and-create-user-dashboard-v85he0
-
- codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
- codex/add-images-and-create-user-dashboard-heebri
-
- codex/add-images-and-create-user-dashboard-ligup1
- main
- main
-main
- main
-          <select id="languageSelect">
-            <option value="en">English</option>
-            <option value="es">Español</option>
-          </select>
-          <button id="updateLang">Update Language</button>
- codex/add-images-and-create-user-dashboard-v85he0
-
-codex/add-images-and-create-user-dashboard-vak73b
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-
- codex/add-images-and-create-user-dashboard-heebri
-
-
-          <span>Current: English</span>
-          <button>Change Language</button>
- main
- main
-main
- main
- main
-        </div>
-      </section>
+        <section class="benefits-banner">
+          <div class="banner-text">
+            <h2>Human-centered benefits for your team.</h2>
+            <p>Offer your employees reliable medical coverage with flexible plan options, curated wellness programs, and dedicated support when they need it most.</p>
+            <p class="banner-meta">&copy;2025 MallowCare | Privacy Policy</p>
+          </div>
+        </section>
+      </div>
     </main>
   </div>
- codex/add-images-and-create-user-dashboard-v85he0
   <script src="profile.js"></script>
-
-codex/add-images-and-create-user-dashboard-vak73b
-  <script src="profile.js"></script>
-
- codex/add-images-and-create-user-dashboard-iq4qsb
-  <script src="profile.js"></script>
-
- codex/add-images-and-create-user-dashboard-heebri
-  <script src="profile.js"></script>
-
- codex/add-images-and-create-user-dashboard-ligup1
-  <script src="profile.js"></script>
- main
- main
- main
- main
- main
 </body>
 </html>

--- a/profile.js
+++ b/profile.js
@@ -1,40 +1,45 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('personalForm');
   const cancelBtn = document.getElementById('cancelBtn');
-  const inputs = form.querySelectorAll('input');
   const languageSelect = document.getElementById('languageSelect');
   const updateLangBtn = document.getElementById('updateLang');
 
-  // Load saved values if available
-  const saved = JSON.parse(localStorage.getItem('personalDetails') || '{}');
-  inputs.forEach(input => {
-    if (saved[input.name]) {
-      input.value = saved[input.name];
-    }
-    input.defaultValue = input.value;
-  });
+  if (form) {
+    const inputs = form.querySelectorAll('input');
+    const saved = JSON.parse(localStorage.getItem('personalDetails') || '{}');
 
-  cancelBtn.addEventListener('click', () => {
-    form.reset();
-  });
-
-  form.addEventListener('submit', (e) => {
-    e.preventDefault();
-    const data = {};
     inputs.forEach(input => {
-      data[input.name] = input.value;
+      if (saved[input.name]) {
+        input.value = saved[input.name];
+      }
       input.defaultValue = input.value;
     });
-    localStorage.setItem('personalDetails', JSON.stringify(data));
-    alert('Changes saved');
-  });
 
-  // Language preference
-  const savedLang = localStorage.getItem('language') || 'en';
-  languageSelect.value = savedLang;
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', () => {
+        form.reset();
+      });
+    }
 
-  updateLangBtn.addEventListener('click', () => {
-    localStorage.setItem('language', languageSelect.value);
-    alert('Language updated');
-  });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const data = {};
+      inputs.forEach(input => {
+        data[input.name] = input.value;
+        input.defaultValue = input.value;
+      });
+      localStorage.setItem('personalDetails', JSON.stringify(data));
+      alert('Changes saved');
+    });
+  }
+
+  if (languageSelect && updateLangBtn) {
+    const savedLang = localStorage.getItem('language') || 'en';
+    languageSelect.value = savedLang;
+
+    updateLangBtn.addEventListener('click', () => {
+      localStorage.setItem('language', languageSelect.value);
+      alert('Language updated');
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- rebuild the individual profile page with a welcome overview, plan status tiles, and quick-action links that match the provided design
- refresh the shared dashboard stylesheet with updated colors, spacing, reusable card styles, and responsive tweaks to support the new layout
- update the profile script to gracefully handle pages that omit the editable form or language selector

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d140909344832795d8e8a1d3a1405f