### PR TITLE
Implement profile beneficiary and documentation forms

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -705,35 +705,26 @@ th {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 1rem;
+  gap: clamp(1rem, 2vw, 1.5rem);
 }
 
 .profile-details .card-header h2 {
   margin: 0;
-  font-size: clamp(1.2rem, 2.4vw, 1.5rem);
+  font-size: clamp(1.2rem, 2.4vw, 1.6rem);
 }
 
 .profile-details .card-header p {
   margin: 0.35rem 0 0;
   color: var(--color-muted);
-  max-width: 460px;
+  max-width: 540px;
 }
 
-.profile-details .card-link {
-  font-weight: 600;
-  color: var(--color-forest-900);
-  text-decoration: underline;
-}
-
-.profile-details .personal-body {
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  align-items: center;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
+.profile-details .card-header > div:first-child {
+  flex: 1;
 }
 
 .profile-details .profile-glyph {
-  width: 120px;
+  width: 108px;
   aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
@@ -748,38 +739,66 @@ th {
   height: auto;
 }
 
-.profile-details .personal-fields h3 {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.4rem, 2.8vw, 1.8rem);
-}
-
-.profile-details .personal-fields p {
-  margin: 0.25rem 0;
-  color: var(--color-muted);
-}
-
-.profile-details .beneficiary-body {
+.profile-details .details-form {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 2rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
 }
 
-.profile-details .beneficiary-details h3 {
-  margin: 0 0 0.35rem;
+.profile-details .form-grid {
+  display: grid;
+  gap: 1rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.profile-details .beneficiary-details p {
-  margin: 0.2rem 0;
-  color: var(--color-muted);
+.profile-details .form-grid.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.profile-details .beneficiary-actions {
+.profile-details .form-field {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.profile-details .form-field span {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-forest-900);
+}
+
+.profile-details .details-form input,
+.profile-details .details-form select {
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(22, 60, 48, 0.18);
+  background: #f6f8f7;
+  font: inherit;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.profile-details .details-form input:focus,
+.profile-details .details-form select:focus {
+  outline: none;
+  border-color: rgba(22, 60, 48, 0.55);
+  box-shadow: 0 0 0 4px rgba(22, 60, 48, 0.12);
+  background: #fff;
+}
+
+.profile-details .details-form select {
+  appearance: none;
+  background-image: url('data:image/svg+xml,%3Csvg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 6l4 4 4-4" stroke="%23163c30" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 16px;
+  padding-right: 2.75rem;
+}
+
+.profile-details .form-actions {
+  display: flex;
   justify-content: flex-end;
+  gap: 0.85rem;
 }
 
 .profile-details .button {
@@ -825,52 +844,53 @@ th {
   background: rgba(22, 60, 48, 0.16);
 }
 
-.profile-details .document-list {
+.profile-details .documents-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.75rem;
 }
 
 .profile-details .document-item {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1.5rem;
-  padding-bottom: 1rem;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-bottom: 1.5rem;
   border-bottom: 1px solid rgba(22, 60, 48, 0.08);
 }
 
-.profile-details .document-item:last-child {
+.profile-details .document-item:last-of-type {
   border-bottom: none;
   padding-bottom: 0;
 }
 
 .profile-details .document-info h3 {
-  margin: 0 0 0.25rem;
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.3rem);
 }
 
 .profile-details .document-info p {
-  margin: 0;
+  margin: 0.35rem 0 0;
   color: var(--color-muted);
+}
+
+.profile-details .document-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .profile-details .document-actions {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
   flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.profile-details .document-actions .button {
-  padding: 0.5rem 1.1rem;
+  align-items: center;
+  gap: 0.75rem 1rem;
 }
 
 .profile-details .status-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem 0.85rem;
+  padding: 0.35rem 1rem;
   border-radius: 999px;
   font-weight: 600;
   font-size: 0.85rem;
@@ -891,60 +911,85 @@ th {
   color: #b71c1c;
 }
 
+.profile-details .file-upload {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.profile-details .file-name {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  word-break: break-word;
+}
+
 .profile-details .language-body {
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .profile-details .language-body p {
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.6rem;
   color: var(--color-muted);
 }
 
-.profile-details .language-body h3 {
-  margin: 0;
-  font-size: clamp(1.2rem, 2.6vw, 1.5rem);
+.profile-details .language-body > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.profile-details .language-body .outline-button {
-  padding-inline: 1.75rem;
+.profile-details .language-select {
+  width: min(220px, 100%);
+  padding: 0.65rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(22, 60, 48, 0.2);
+  background: #fff;
+  font: inherit;
+  appearance: none;
+  background-image: url('data:image/svg+xml,%3Csvg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 6l4 4 4-4" stroke="%23163c30" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 16px;
+  padding-right: 2.75rem;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 @media (max-width: 900px) {
-  .profile-details .personal-body {
-    grid-template-columns: minmax(0, 1fr);
-    justify-items: flex-start;
+  .profile-details .card-header {
+    flex-direction: column;
   }
 
   .profile-details .profile-glyph {
     width: 96px;
-    margin-bottom: 0.5rem;
   }
 
-  .profile-details .beneficiary-body {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .profile-details .beneficiary-actions {
+  .profile-details .form-actions {
+    flex-wrap: wrap;
     justify-content: flex-start;
   }
+}
 
-  .profile-details .document-item {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
+@media (max-width: 700px) {
   .profile-details .document-actions {
-    justify-content: flex-start;
-  }
-
-  .profile-details .language-body {
     flex-direction: column;
     align-items: flex-start;
   }
 }
+
 

--- a/my-profile.html
+++ b/my-profile.html
@@ -43,82 +43,245 @@
 
       <section class="info-card personal-card">
         <div class="card-header">
-          <h2>Personal Details</h2>
-          <a href="settings.html" class="card-link">Edit Profile</a>
-        </div>
-        <div class="personal-body">
+          <div>
+            <h2>Personal Details</h2>
+            <p>Update your contact information so we can reach you without delays.</p>
+          </div>
           <div class="profile-glyph" aria-hidden="true">
             <svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="presentation">
               <circle cx="60" cy="60" r="56" fill="#fbf5e7" />
               <path d="M88 42c-6-8-16-13-27-13-16 0-30 11-33 26-3 17 10 32 30 32 16 0 28-11 28-25 0-11-8-19-19-19-8 0-15 5-16 12-1 6 3 11 9 11 5 0 8-3 9-7" fill="none" stroke="#d8b86a" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
           </div>
-          <div class="personal-fields">
-            <h3>Maria Thompson</h3>
-            <p>maria.thompson@email.com</p>
-            <p>+1 (555) 123-4567</p>
-            <p>123 Main Street, Miami, FL 33130</p>
-          </div>
         </div>
+        <form id="personalForm" class="details-form">
+          <div class="form-grid two-column">
+            <label class="form-field">
+              <span>First Name</span>
+              <input type="text" name="firstName" value="Maria" autocomplete="given-name" required>
+            </label>
+            <label class="form-field">
+              <span>Last Name</span>
+              <input type="text" name="lastName" value="Thompson" autocomplete="family-name" required>
+            </label>
+            <label class="form-field">
+              <span>Email Address</span>
+              <input type="email" name="email" value="maria.thompson@email.com" autocomplete="email" required>
+            </label>
+            <label class="form-field">
+              <span>Phone Number</span>
+              <input type="tel" name="phone" value="+1 (555) 123-4567" autocomplete="tel" required>
+            </label>
+            <label class="form-field">
+              <span>Date of Birth</span>
+              <input type="date" name="dob" value="1988-07-12" autocomplete="bday" required>
+            </label>
+            <label class="form-field">
+              <span>Member ID</span>
+              <input type="text" name="memberId" value="MT-482195" autocomplete="off" required>
+            </label>
+            <label class="form-field">
+              <span>Address Line 1</span>
+              <input type="text" name="address1" value="123 Main Street" autocomplete="address-line1" required>
+            </label>
+            <label class="form-field">
+              <span>Address Line 2</span>
+              <input type="text" name="address2" value="Unit 402" autocomplete="address-line2">
+            </label>
+            <label class="form-field">
+              <span>City</span>
+              <input type="text" name="city" value="Miami" autocomplete="address-level2" required>
+            </label>
+            <label class="form-field">
+              <span>State</span>
+              <input type="text" name="state" value="FL" autocomplete="address-level1" required>
+            </label>
+            <label class="form-field">
+              <span>Postal Code</span>
+              <input type="text" name="postal" value="33130" autocomplete="postal-code" required>
+            </label>
+            <label class="form-field">
+              <span>Preferred Contact Method</span>
+              <select name="contactMethod" required>
+                <option value="email" selected>Email</option>
+                <option value="phone">Phone</option>
+                <option value="sms">Text Message</option>
+              </select>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="button" class="button outline-button" data-action="cancel">Cancel</button>
+            <button type="submit" class="button solid-button">Save Changes</button>
+          </div>
+        </form>
       </section>
 
       <section class="info-card beneficiary-card">
         <div class="card-header">
-          <h2>My Beneficiary</h2>
-        </div>
-        <div class="beneficiary-body">
-          <div class="beneficiary-details">
-            <h3>Nicole Thompson</h3>
-            <p>Primary Beneficiary</p>
-            <p>+1 (555) 987-6543</p>
-            <p>123 Biscayne Blvd, Miami, FL 33132</p>
-          </div>
-          <div class="beneficiary-actions">
-            <button class="button outline-button">Add Beneficiary</button>
-            <button class="button solid-button">Edit / Remove Beneficiary</button>
+          <div>
+            <h2>My Beneficiary</h2>
+            <p>Share who should receive your benefits and how to contact them.</p>
           </div>
         </div>
+        <form id="beneficiaryForm" class="details-form">
+          <div class="form-grid two-column">
+            <label class="form-field">
+              <span>Full Name</span>
+              <input type="text" name="beneficiaryName" value="Nicole Thompson" required>
+            </label>
+            <label class="form-field">
+              <span>Relationship</span>
+              <select name="relationship" required>
+                <option value="spouse">Spouse</option>
+                <option value="child" selected>Child</option>
+                <option value="parent">Parent</option>
+                <option value="sibling">Sibling</option>
+                <option value="other">Other</option>
+              </select>
+            </label>
+            <label class="form-field">
+              <span>Email Address</span>
+              <input type="email" name="beneficiaryEmail" value="nicole.thompson@email.com" required>
+            </label>
+            <label class="form-field">
+              <span>Phone Number</span>
+              <input type="tel" name="beneficiaryPhone" value="+1 (555) 987-6543" required>
+            </label>
+            <label class="form-field">
+              <span>Address Line 1</span>
+              <input type="text" name="beneficiaryAddress1" value="123 Biscayne Blvd" required>
+            </label>
+            <label class="form-field">
+              <span>Address Line 2</span>
+              <input type="text" name="beneficiaryAddress2" value="Apartment 11B">
+            </label>
+            <label class="form-field">
+              <span>City</span>
+              <input type="text" name="beneficiaryCity" value="Miami" required>
+            </label>
+            <label class="form-field">
+              <span>State</span>
+              <input type="text" name="beneficiaryState" value="FL" required>
+            </label>
+            <label class="form-field">
+              <span>Postal Code</span>
+              <input type="text" name="beneficiaryPostal" value="33132" required>
+            </label>
+            <label class="form-field">
+              <span>Percentage Allocation</span>
+              <input type="number" name="beneficiaryPercentage" value="100" min="0" max="100" required>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="button" class="button outline-button" data-action="cancel">Cancel</button>
+            <button type="submit" class="button solid-button">Save Beneficiary</button>
+          </div>
+        </form>
       </section>
 
       <section class="info-card documents-card">
         <div class="card-header">
           <div>
             <h2>Identification Documents</h2>
-            <p>Keep your identification up to date to avoid coverage interruptions.</p>
+            <p>Upload current identification so we can verify your eligibility and beneficiary claims.</p>
           </div>
         </div>
-        <div class="document-list">
+        <form id="documentsForm" class="details-form documents-form">
           <article class="document-item">
             <div class="document-info">
               <h3>Passport</h3>
-              <p>Uploaded March 2, 2025</p>
+              <p>Upload a clear scan of the picture page.</p>
             </div>
-            <div class="document-actions">
-              <span class="status-pill status-success">Uploaded</span>
-              <button class="button ghost-button">Upload / Replace Document</button>
+            <div class="document-fields">
+              <div class="form-grid">
+                <label class="form-field">
+                  <span>Status</span>
+                  <select name="passportStatus" data-status-pill="passportStatusPill">
+                    <option value="uploaded" selected>Uploaded</option>
+                    <option value="expiring">Expiring Soon</option>
+                    <option value="pending">Not Submitted</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Expiration Date</span>
+                  <input type="date" name="passportExpiry" value="2026-03-02">
+                </label>
+              </div>
+              <div class="document-actions">
+                <span class="status-pill status-success" data-status-pill-target="passportStatusPill">Uploaded</span>
+                <label class="button ghost-button file-upload">
+                  <input type="file" name="passportFile" accept="image/*,.pdf" data-file-output="passportFileName" hidden>
+                  <span>Upload / Replace Document</span>
+                </label>
+                <span class="file-name" data-file-name="passportFileName" data-placeholder="No document uploaded">Passport_Maria.pdf</span>
+              </div>
             </div>
           </article>
           <article class="document-item">
             <div class="document-info">
               <h3>Driver's License</h3>
-              <p>Expiring October 18, 2025</p>
+              <p>Ensure the address matches your current residence.</p>
             </div>
-            <div class="document-actions">
-              <span class="status-pill status-warning">Expiring Soon</span>
-              <button class="button ghost-button">Upload / Replace Document</button>
+            <div class="document-fields">
+              <div class="form-grid">
+                <label class="form-field">
+                  <span>Status</span>
+                  <select name="licenseStatus" data-status-pill="licenseStatusPill">
+                    <option value="uploaded">Uploaded</option>
+                    <option value="expiring" selected>Expiring Soon</option>
+                    <option value="pending">Not Submitted</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Expiration Date</span>
+                  <input type="date" name="licenseExpiry" value="2025-10-18">
+                </label>
+              </div>
+              <div class="document-actions">
+                <span class="status-pill status-warning" data-status-pill-target="licenseStatusPill">Expiring Soon</span>
+                <label class="button ghost-button file-upload">
+                  <input type="file" name="licenseFile" accept="image/*,.pdf" data-file-output="licenseFileName" hidden>
+                  <span>Upload / Replace Document</span>
+                </label>
+                <span class="file-name" data-file-name="licenseFileName" data-placeholder="No document uploaded">DriversLicense_Maria.pdf</span>
+              </div>
             </div>
           </article>
           <article class="document-item">
             <div class="document-info">
               <h3>Social Security</h3>
-              <p>Required for beneficiary payouts</p>
+              <p>Required for beneficiary payouts and tax reporting.</p>
             </div>
-            <div class="document-actions">
-              <span class="status-pill status-pending">Not Submitted</span>
-              <button class="button ghost-button">Upload Document</button>
+            <div class="document-fields">
+              <div class="form-grid">
+                <label class="form-field">
+                  <span>Status</span>
+                  <select name="ssnStatus" data-status-pill="ssnStatusPill">
+                    <option value="uploaded">Uploaded</option>
+                    <option value="expiring">Expiring Soon</option>
+                    <option value="pending" selected>Not Submitted</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Last Updated</span>
+                  <input type="date" name="ssnUpdated" value="">
+                </label>
+              </div>
+              <div class="document-actions">
+                <span class="status-pill status-pending" data-status-pill-target="ssnStatusPill">Not Submitted</span>
+                <label class="button ghost-button file-upload">
+                  <input type="file" name="ssnFile" accept="image/*,.pdf" data-file-output="ssnFileName" hidden>
+                  <span>Upload Document</span>
+                </label>
+                <span class="file-name" data-file-name="ssnFileName" data-placeholder="No document uploaded">No document uploaded</span>
+              </div>
             </div>
           </article>
-        </div>
+          <div class="form-actions">
+            <button type="button" class="button outline-button" data-action="cancel">Cancel</button>
+            <button type="submit" class="button solid-button">Save Documents</button>
+          </div>
+        </form>
       </section>
 
       <section class="info-card language-card">
@@ -127,10 +290,15 @@
         </div>
         <div class="language-body">
           <div>
-            <p>Current</p>
-            <h3>English</h3>
+            <p>Choose the language for emails, notifications, and support.</p>
+            <label class="visually-hidden" for="languageSelect">Language</label>
+            <select id="languageSelect" class="language-select">
+              <option value="en" selected>English</option>
+              <option value="es">Español</option>
+              <option value="fr">Français</option>
+            </select>
           </div>
-          <button class="button outline-button">Update Preference</button>
+          <button class="button outline-button" id="updateLang">Update Preference</button>
         </div>
       </section>
     </main>

--- a/profile.js
+++ b/profile.js
@@ -1,45 +1,173 @@
+const STATUS_MAP = {
+  uploaded: { label: 'Uploaded', className: 'status-success' },
+  expiring: { label: 'Expiring Soon', className: 'status-warning' },
+  pending: { label: 'Not Submitted', className: 'status-pending' }
+};
+
 document.addEventListener('DOMContentLoaded', () => {
-  const form = document.getElementById('personalForm');
-  const cancelBtn = document.getElementById('cancelBtn');
-  const languageSelect = document.getElementById('languageSelect');
-  const updateLangBtn = document.getElementById('updateLang');
+  const formConfigs = [
+    { id: 'personalForm', storageKey: 'personalDetails', successMessage: 'Personal details updated' },
+    { id: 'beneficiaryForm', storageKey: 'beneficiaryDetails', successMessage: 'Beneficiary information saved' },
+    { id: 'documentsForm', storageKey: 'documentDetails', successMessage: 'Document details updated' }
+  ];
 
-  if (form) {
-    const inputs = form.querySelectorAll('input');
-    const saved = JSON.parse(localStorage.getItem('personalDetails') || '{}');
+  formConfigs.forEach(setupForm);
+  setupStatusPills();
+  setupLanguagePreference();
+});
 
-    inputs.forEach(input => {
-      if (saved[input.name]) {
-        input.value = saved[input.name];
+function setupForm({ id, storageKey, successMessage }) {
+  const form = document.getElementById(id);
+  if (!form) return;
+
+  const inputs = Array.from(form.querySelectorAll('input, select, textarea'));
+  let savedData = readStoredData(storageKey);
+
+  inputs.forEach(input => {
+    if (input.type === 'file') {
+      const output = getFileOutput(form, input);
+      const savedName = savedData[input.name];
+      if (output) {
+        const placeholder = output.dataset.placeholder || output.textContent || 'No document uploaded';
+        output.dataset.placeholder = placeholder;
+        output.textContent = savedName || placeholder;
+      }
+      input.value = '';
+    } else {
+      if (Object.prototype.hasOwnProperty.call(savedData, input.name)) {
+        input.value = savedData[input.name];
       }
       input.defaultValue = input.value;
+    }
+  });
+
+  inputs
+    .filter(input => input.type === 'file')
+    .forEach(input => {
+      const output = getFileOutput(form, input);
+      input.addEventListener('change', () => {
+        if (!output) return;
+        if (input.files.length) {
+          output.textContent = input.files[0].name;
+        } else {
+          const savedName = savedData[input.name];
+          output.textContent = savedName || output.dataset.placeholder || 'No document uploaded';
+        }
+      });
     });
 
-    if (cancelBtn) {
-      cancelBtn.addEventListener('click', () => {
-        form.reset();
+  const cancelBtn = form.querySelector('[data-action="cancel"]');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      inputs.forEach(input => {
+        if (input.type === 'file') {
+          input.value = '';
+          const output = getFileOutput(form, input);
+          if (output) {
+            const savedName = savedData[input.name];
+            output.textContent = savedName || output.dataset.placeholder || 'No document uploaded';
+          }
+        } else {
+          input.value = input.defaultValue;
+          if (input.tagName === 'SELECT' && input.dataset.statusPill) {
+            input.dispatchEvent(new Event('change'));
+          }
+        }
       });
+    });
+  }
+
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    const updated = {};
+
+    inputs.forEach(input => {
+      if (input.type === 'file') {
+        const output = getFileOutput(form, input);
+        if (input.files.length) {
+          const fileName = input.files[0].name;
+          updated[input.name] = fileName;
+          if (output) {
+            output.textContent = fileName;
+          }
+        } else if (savedData[input.name]) {
+          updated[input.name] = savedData[input.name];
+          if (output) {
+            output.textContent = savedData[input.name];
+          }
+        } else if (output) {
+          output.textContent = output.dataset.placeholder || 'No document uploaded';
+        }
+        input.value = '';
+      } else {
+        updated[input.name] = input.value;
+        input.defaultValue = input.value;
+        if (input.tagName === 'SELECT' && input.dataset.statusPill) {
+          input.dispatchEvent(new Event('change'));
+        }
+      }
+    });
+
+    savedData = updated;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(updated));
+    } catch (error) {
+      console.error('Unable to persist form data', error);
     }
 
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      const data = {};
-      inputs.forEach(input => {
-        data[input.name] = input.value;
-        input.defaultValue = input.value;
-      });
-      localStorage.setItem('personalDetails', JSON.stringify(data));
-      alert('Changes saved');
-    });
+    alert(successMessage || 'Changes saved');
+  });
+}
+
+function setupStatusPills() {
+  const selects = document.querySelectorAll('select[data-status-pill]');
+  selects.forEach(select => {
+    const pill = document.querySelector(`[data-status-pill-target="${select.dataset.statusPill}"]`);
+    if (!pill) return;
+
+    const applyStatus = value => {
+      const status = STATUS_MAP[value] || STATUS_MAP.pending;
+      pill.textContent = status.label;
+      pill.classList.remove('status-success', 'status-warning', 'status-pending');
+      pill.classList.add(status.className);
+    };
+
+    applyStatus(select.value);
+    select.addEventListener('change', () => applyStatus(select.value));
+  });
+}
+
+function setupLanguagePreference() {
+  const languageSelect = document.getElementById('languageSelect');
+  const updateLangBtn = document.getElementById('updateLang');
+  if (!languageSelect || !updateLangBtn) {
+    return;
   }
 
-  if (languageSelect && updateLangBtn) {
-    const savedLang = localStorage.getItem('language') || 'en';
+  const savedLang = localStorage.getItem('language');
+  if (savedLang) {
     languageSelect.value = savedLang;
-
-    updateLangBtn.addEventListener('click', () => {
-      localStorage.setItem('language', languageSelect.value);
-      alert('Language updated');
-    });
   }
-});
+
+  updateLangBtn.addEventListener('click', () => {
+    localStorage.setItem('language', languageSelect.value);
+    alert('Language preference updated');
+  });
+}
+
+function readStoredData(key) {
+  if (!key) return {};
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : {};
+  } catch (error) {
+    console.warn('Unable to parse stored data for', key, error);
+    return {};
+  }
+}
+
+function getFileOutput(form, input) {
+  const target = input.dataset.fileOutput;
+  if (!target) return null;
+  return form.querySelector(`[data-file-name="${target}"]`);
+}


### PR DESCRIPTION
## Summary
- convert the profile view into fully editable personal, beneficiary, and identification document forms
- refresh the profile styles to support responsive two-column grids, upload controls, and language preference select
- enhance profile.js to persist each form, sync document status pills, and handle language preference storage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d15818981883279ac231798fec27f4