### PR TITLE
Make edit form update only right column fields

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -218,6 +218,25 @@ button {
   margin-bottom: 1.25rem;
 }
 
+.form-columns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.form-column {
+  flex: 1 1 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-column .form-group {
+  flex: none;
+  min-width: 0;
+}
+
 .form-group {
   flex: 1;
   min-width: 200px;
@@ -239,6 +258,11 @@ button {
   background: #fff;
   font-size: 1rem;
   color: inherit;
+}
+
+.form-group input[readonly] {
+  background: rgba(22, 60, 48, 0.08);
+  cursor: not-allowed;
 }
 
 .form-group input:focus,

--- a/members.js
+++ b/members.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function updateSelects() {
     const members = loadMembers();
     [editSelect, removeSelect].forEach(sel => {
-      sel.innerHTML = '<option value="">Select</option>';
+      sel.innerHTML = '<option value="">Select Member</option>';
       members.forEach((m, idx) => {
         const opt = document.createElement('option');
         opt.value = idx;
@@ -67,7 +67,11 @@ document.addEventListener('DOMContentLoaded', () => {
       lastName: addForm.lastName.value,
       dob: addForm.dob.value,
       relation: addForm.relation.value,
-      idExpiration: addForm.expiration.value
+      idExpiration: addForm.expiration.value,
+      address: '',
+      city: '',
+      state: '',
+      zip: ''
     };
     const members = loadMembers();
     members.push(member);
@@ -87,12 +91,20 @@ document.addEventListener('DOMContentLoaded', () => {
       editForm.reset();
       return;
     }
-    const member = loadMembers()[idx];
+    const members = loadMembers();
+    const member = members[idx];
+    if (!member) {
+      editForm.reset();
+      return;
+    }
     editForm.firstName.value = member.firstName;
     editForm.lastName.value = member.lastName;
     editForm.dob.value = member.dob;
     editForm.relation.value = member.relation;
-    editForm.expiration.value = member.idExpiration;
+    editForm.address.value = member.address || '';
+    editForm.city.value = member.city || '';
+    editForm.state.value = member.state || '';
+    editForm.zip.value = member.zip || '';
   });
 
   editForm.addEventListener('submit', e => {
@@ -101,11 +113,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (idx === '') return;
     const members = loadMembers();
     members[idx] = {
-      firstName: editForm.firstName.value,
-      lastName: editForm.lastName.value,
-      dob: editForm.dob.value,
-      relation: editForm.relation.value,
-      idExpiration: editForm.expiration.value
+      ...members[idx],
+      address: editForm.address.value,
+      city: editForm.city.value,
+      state: editForm.state.value,
+      zip: editForm.zip.value
     };
     saveMembers(members);
     renderTable();

--- a/protected-members.html
+++ b/protected-members.html
@@ -18,22 +18,10 @@
         <p>Welcome to your Dashboard</p>
       </div>
       <nav class="menu">
-codex/add-images-and-create-user-dashboard-v85he0
         <a href="my-profile.html" class="active">My Account</a>
         <a href="payments.html">Payments</a>
         <a href="#">Help</a>
         <a href="settings.html">Settings</a>
-
- codex/add-images-and-create-user-dashboard-vak73b
-        <a href="my-profile.html" class="active">My Account</a>
-        <a href="payments.html">Payments</a>
-
-        <a href="#" class="active">My Account</a>
-        <a href="#">Payments</a>
-main
-        <a href="#">Help</a>
-        <a href="#">Settings</a>
- main
       </nav>
       <div class="sidebar-bottom">
         <button class="logout">Log Out</button>
@@ -50,7 +38,7 @@ main
       <section class="section-card members-table">
         <div class="table-header">
           <h2>Who's Protected</h2>
-          <button id="toAdd">Add Member</button>
+          <button id="toAdd">+ Add Member</button>
         </div>
         <table id="membersTable">
           <thead>
@@ -105,37 +93,51 @@ main
         <form id="editMemberForm">
           <div class="form-row">
             <div class="form-group">
-              <label for="editSelect">Select</label>
+              <label for="editSelect">Select Member</label>
               <select id="editSelect"></select>
             </div>
           </div>
-          <div class="form-row">
-            <div class="form-group">
-              <label for="editFirstName">First Name</label>
-              <input type="text" id="editFirstName" name="firstName" required>
+          <div class="form-columns">
+            <div class="form-column">
+              <div class="form-group">
+                <label for="editFirstName">First Name</label>
+                <input type="text" id="editFirstName" name="firstName" readonly>
+              </div>
+              <div class="form-group">
+                <label for="editLastName">Last Name</label>
+                <input type="text" id="editLastName" name="lastName" readonly>
+              </div>
+              <div class="form-group">
+                <label for="editRelation">Relationship</label>
+                <input type="text" id="editRelation" name="relation" readonly>
+              </div>
+              <div class="form-group">
+                <label for="editDob">Date of Birth</label>
+                <input type="date" id="editDob" name="dob" readonly>
+              </div>
             </div>
-            <div class="form-group">
-              <label for="editLastName">Last Name</label>
-              <input type="text" id="editLastName" name="lastName" required>
-            </div>
-            <div class="form-group">
-              <label for="editDob">Date of Birth</label>
-              <input type="date" id="editDob" name="dob" required>
-            </div>
-            <div class="form-group">
-              <label for="editRelation">Relation</label>
-              <input type="text" id="editRelation" name="relation" required>
-            </div>
-          </div>
-          <div class="form-row">
-            <div class="form-group">
-              <label for="editExpiration">ID/Passport Expiration</label>
-              <input type="date" id="editExpiration" name="expiration">
+            <div class="form-column">
+              <div class="form-group">
+                <label for="editAddress">Address</label>
+                <input type="text" id="editAddress" name="address" placeholder="Enter address">
+              </div>
+              <div class="form-group">
+                <label for="editCity">City</label>
+                <input type="text" id="editCity" name="city" placeholder="Enter city">
+              </div>
+              <div class="form-group">
+                <label for="editState">State</label>
+                <input type="text" id="editState" name="state" placeholder="Enter state">
+              </div>
+              <div class="form-group">
+                <label for="editZip">Zip Code</label>
+                <input type="text" id="editZip" name="zip" placeholder="Enter zip code">
+              </div>
             </div>
           </div>
           <div class="form-actions">
             <button type="button" class="cancel" id="cancelEdit">Cancel</button>
-            <button type="submit">Update Member</button>
+            <button type="submit">Save Changes</button>
           </div>
         </form>
       </section>
@@ -145,7 +147,7 @@ main
         <form id="removeMemberForm">
           <div class="form-row">
             <div class="form-group">
-              <label for="removeSelect">Select</label>
+              <label for="removeSelect">Select Member</label>
               <select id="removeSelect"></select>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- clean up the protected members navigation markup and tweak the add button copy
- restructure the edit member form into read-only left details and editable right contact fields
- extend member storage and styles so edits only persist the right-column address details

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d321eeb2a48327b8434cde4a588a7c