### PR TITLE
Revamp settings experience

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -41,6 +41,67 @@ button {
   color: inherit;
 }
 
+.button {
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(31, 87, 72, 0.4);
+  outline-offset: 2px;
+}
+
+.solid-button {
+  background: var(--color-forest-900);
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(17, 40, 32, 0.22);
+}
+
+.solid-button:hover {
+  transform: translateY(-1px);
+}
+
+.outline-button {
+  background: transparent;
+  color: var(--color-forest-900);
+  border: 2px solid rgba(22, 60, 48, 0.35);
+}
+
+.outline-button:hover {
+  background: rgba(22, 60, 48, 0.08);
+}
+
+.ghost-button {
+  background: rgba(22, 60, 48, 0.08);
+  color: var(--color-forest-900);
+}
+
+.ghost-button:hover {
+  background: rgba(22, 60, 48, 0.16);
+}
+
+.danger-button {
+  background: #c62828;
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(198, 40, 40, 0.3);
+}
+
+.danger-button:hover {
+  transform: translateY(-1px);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
 .dashboard {
   min-height: 100vh;
   display: flex;
@@ -308,8 +369,7 @@ th {
 .members-table button,
 .payment-history button,
 .plan-type .plan-row button,
-.plan-overview button,
-.settings-section .option-row button {
+.plan-overview button {
   background: var(--color-forest-900);
   color: #fff;
   border: none;
@@ -323,16 +383,14 @@ th {
 .members-table button:hover,
 .payment-history button:hover,
 .plan-type .plan-row button:hover,
-.plan-overview button:hover,
-.settings-section .option-row button:hover {
+.plan-overview button:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(17, 40, 32, 0.18);
 }
 
 .members-table .delete-btn,
 .payment-history .delete-btn,
-.plan-type .plan-row .expire-btn,
-.settings-section .option-row .danger {
+.plan-type .plan-row .expire-btn {
   background: #c62828;
 }
 
@@ -397,54 +455,484 @@ th {
 }
 
 /* Settings */
-.settings-section .option-row {
+.settings-main {
+  gap: clamp(2rem, 3vw, 2.8rem);
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.settings-header h1 {
+  margin: 0;
+}
+
+.settings-header .member-since {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.settings-hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(125deg, #fbf5e7 0%, #fdfaf2 60%, #f4e2bc 100%);
+  border-radius: var(--radius-large);
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: var(--shadow-card);
+}
+
+.settings-hero .hero-copy {
+  flex: 1 1 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-hero .hero-copy h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.settings-hero .hero-copy p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.settings-hero .hero-meta {
+  flex: 1 1 220px;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin: 0;
+}
+
+.settings-hero .hero-meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.settings-hero .hero-meta dt {
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+
+.settings-hero .hero-meta dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--color-forest-900);
+}
+
+.settings-layout {
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  align-items: start;
+}
+
+.settings-nav {
+  background: #fff;
+  border-radius: var(--radius-medium);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  box-shadow: 0 22px 38px rgba(17, 40, 32, 0.08);
+}
+
+.settings-nav .nav-heading h2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.settings-nav .nav-heading p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.settings-nav .nav-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-nav .nav-link {
+  border-radius: 12px;
+  background: rgba(22, 60, 48, 0.08);
+  color: var(--color-forest-900);
+  text-align: left;
+  padding: 0.85rem 1.1rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-nav .nav-link:hover,
+.settings-nav .nav-link:focus-visible {
+  background: rgba(22, 60, 48, 0.14);
+}
+
+.settings-nav .nav-link.active {
+  background: var(--color-forest-900);
+  color: #fff;
+  box-shadow: 0 20px 30px rgba(17, 40, 32, 0.18);
+}
+
+.settings-nav .nav-support {
+  background: rgba(22, 60, 48, 0.06);
+  border-radius: 12px;
+  padding: 1.25rem 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.settings-nav .nav-support h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.settings-nav .nav-support p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.settings-nav .support-link {
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.settings-panel {
+  background: #fff;
+  border-radius: var(--radius-medium);
+  padding: clamp(1.75rem, 3vw, 2.25rem);
+  box-shadow: 0 22px 38px rgba(17, 40, 32, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+.panel-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 2.5vw, 1.9rem);
+}
+
+.panel-header p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.preference-list,
+.security-grid,
+.data-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.preference-item,
+.security-item,
+.data-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid rgba(22, 60, 48, 0.12);
 }
 
-.switch {
+.preference-item:last-child,
+.security-item:last-child,
+.data-item:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.preference-copy h3,
+.security-item h3,
+.data-item h3 {
+  margin: 0 0 0.3rem;
+  font-size: 1.1rem;
+}
+
+.preference-copy p,
+.security-item p,
+.data-item p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.panel-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  background: rgba(22, 60, 48, 0.1);
+  color: var(--color-forest-900);
+  white-space: nowrap;
+}
+
+.status-pill.success {
+  background: #e4f3e8;
+  color: #1a7f52;
+}
+
+.status-pill.neutral {
+  background: rgba(22, 60, 48, 0.12);
+  color: var(--color-muted);
+}
+
+.toggle {
   position: relative;
-  display: inline-block;
-  width: 44px;
-  height: 22px;
+  display: inline-flex;
+  width: 52px;
+  height: 28px;
+  align-items: center;
 }
 
-.switch input {
+.toggle input {
   opacity: 0;
   width: 0;
   height: 0;
+  position: absolute;
 }
 
-.slider {
-  position: absolute;
-  cursor: pointer;
-  inset: 0;
+.toggle-control {
+  position: relative;
+  display: inline-flex;
+  width: 100%;
+  height: 100%;
   background: #cfd8d3;
-  transition: 0.4s;
   border-radius: 999px;
+  transition: background 0.3s ease;
 }
 
-.slider:before {
+.toggle-control::before {
+  content: '';
   position: absolute;
-  content: "";
-  height: 18px;
-  width: 18px;
-  left: 2px;
-  bottom: 2px;
-  background: #fff;
-  transition: 0.4s;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
+  background: #fff;
+  left: 4px;
+  top: 3px;
+  transition: transform 0.3s ease;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
 }
 
-.switch input:checked + .slider {
+.toggle input:checked + .toggle-control {
   background: var(--color-forest-900);
 }
 
-.switch input:checked + .slider:before {
-  transform: translateX(22px);
+.toggle input:checked + .toggle-control::before {
+  transform: translateX(24px);
+}
+
+.data-item.danger {
+  background: rgba(198, 40, 40, 0.06);
+  border-radius: 14px;
+  padding: 1.35rem;
+  border: 1px solid rgba(198, 40, 40, 0.25);
+  border-bottom: none;
+}
+
+.data-item.danger h3 {
+  color: #c62828;
+}
+
+.data-item.danger p {
+  color: rgba(198, 40, 40, 0.85);
+}
+
+.data-item.danger + .data-item {
+  border-top: none;
+}
+
+.settings-panel[hidden] {
+  display: none !important;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 35, 28, 0.55);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.modal.open {
+  display: flex;
+}
+
+.modal-card {
+  background: #fff;
+  border-radius: 20px;
+  max-width: 520px;
+  width: min(520px, 100%);
+  padding: 2.25rem;
+  box-shadow: 0 30px 60px rgba(12, 35, 28, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.modal-header h2 {
+  margin: 0.35rem 0 0.5rem;
+}
+
+.modal-header p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.modal-close {
+  background: rgba(22, 60, 48, 0.08);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.modal-close:hover {
+  background: rgba(22, 60, 48, 0.16);
+}
+
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.modal-field span {
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.modal-field input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(22, 60, 48, 0.2);
+  font: inherit;
+}
+
+.modal-field input:focus {
+  outline: none;
+  border-color: rgba(22, 60, 48, 0.55);
+  box-shadow: 0 0 0 4px rgba(22, 60, 48, 0.12);
+}
+
+.password-hint {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 1024px) {
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-nav {
+    position: relative;
+    top: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .settings-hero {
+    padding: 1.75rem;
+  }
+
+  .settings-panel {
+    padding: 1.5rem;
+  }
+
+  .panel-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .panel-actions .button {
+    width: 100%;
+    text-align: center;
+  }
+
+  .preference-item,
+  .security-item,
+  .data-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .item-actions {
+    align-self: stretch;
+    justify-content: space-between;
+  }
+
+  .toggle {
+    align-self: flex-end;
+  }
 }
 
 /* Profile overview */

--- a/settings.html
+++ b/settings.html
@@ -10,10 +10,10 @@
   <link rel="stylesheet" href="dashboard.css">
 </head>
 <body>
-  <div class="dashboard">
+  <div class="dashboard settings-dashboard">
     <aside class="sidebar">
       <div class="profile">
-        <img src="images/flying-kite.jpg" alt="Profile picture">
+        <img src="images/flying-kite.jpg" alt="Portrait of Maria Thompson">
         <h2>Maria Thompson</h2>
         <p>Welcome to your Dashboard</p>
       </div>
@@ -26,67 +26,218 @@
       <div class="sidebar-bottom">
         <button class="logout">Log Out</button>
         <div class="lang">
-          <button>English</button>
+          <button class="active">English</button>
           <button>Español</button>
         </div>
       </div>
     </aside>
-    <main class="main-content">
-      <div class="breadcrumb">Dashboard - Settings</div>
-      <h1>Settings</h1>
 
-      <section class="section-card settings-section" id="notificationsSection">
-        <h2>Notifications</h2>
-        <div class="option-row">
-          <span>Email Notifications</span>
-          <label class="switch">
-            <input type="checkbox" id="emailNotif">
-            <span class="slider"></span>
-          </label>
+    <main class="main-content settings-main">
+      <header class="content-header settings-header">
+        <div>
+          <span class="eyebrow">Account Center</span>
+          <h1>Settings</h1>
         </div>
-        <div class="option-row">
-          <span>Push Notifications</span>
-          <label class="switch">
-            <input type="checkbox" id="pushNotif">
-            <span class="slider"></span>
-          </label>
+        <p class="member-since">Last reviewed April 4, 2024</p>
+      </header>
+
+      <section class="settings-hero" aria-label="Account overview">
+        <div class="hero-copy">
+          <h2>Keep your preferences in sync</h2>
+          <p>Control how Ivy keeps you informed, protect your account security, and manage the information we store for you.</p>
         </div>
-        <div class="option-row">
-          <span>SMS Notifications</span>
-          <label class="switch">
-            <input type="checkbox" id="smsNotif">
-            <span class="slider"></span>
-          </label>
-        </div>
-        <div class="form-actions">
-          <button id="saveNotifs">Save Changes</button>
-        </div>
+        <dl class="hero-meta">
+          <div>
+            <dt>Plan</dt>
+            <dd>Ivy Family Plus</dd>
+          </div>
+          <div>
+            <dt>Member ID</dt>
+            <dd>MT-482195</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd class="status-pill success">Active</dd>
+          </div>
+        </dl>
       </section>
 
-      <section class="section-card settings-section" id="privacySection">
-        <h2>Privacy &amp; Security</h2>
-        <div class="option-row">
-          <span>Password</span>
-          <button id="changePassword">Change</button>
-        </div>
-        <div class="option-row">
-          <span>Two-Factor Authentication</span>
-          <button id="toggle2FA">Enable</button>
-        </div>
-      </section>
+      <div class="settings-layout">
+        <aside class="settings-nav" aria-label="Settings sections">
+          <div class="nav-heading">
+            <span class="eyebrow">Ivy Settings</span>
+            <h2>Manage your experience</h2>
+            <p>Select a category to update how we stay connected and protect your membership.</p>
+          </div>
+          <nav class="nav-links" role="tablist">
+            <button class="nav-link active" id="tabNotifications" type="button" role="tab" aria-selected="true" aria-controls="notificationsPanel" data-target="notificationsPanel">Notifications</button>
+            <button class="nav-link" id="tabPrivacy" type="button" role="tab" aria-selected="false" aria-controls="privacyPanel" data-target="privacyPanel">Privacy &amp; Security</button>
+            <button class="nav-link" id="tabData" type="button" role="tab" aria-selected="false" aria-controls="dataPanel" data-target="dataPanel">Data &amp; Privacy</button>
+          </nav>
+          <div class="nav-support">
+            <h3>Need assistance?</h3>
+            <p>Visit the help center to chat with a care specialist or explore common questions.</p>
+            <a href="#" class="support-link">Go to Help Center</a>
+          </div>
+        </aside>
 
-      <section class="section-card settings-section" id="dataSection">
-        <h2>Data &amp; Privacy</h2>
-        <div class="option-row">
-          <span>Download My Data</span>
-          <button id="downloadData">Download</button>
+        <div class="settings-content" role="presentation">
+          <section id="notificationsPanel" class="settings-panel active" role="tabpanel" aria-labelledby="tabNotifications" tabindex="0">
+            <header class="panel-header">
+              <h2 id="notificationsTitle">Notifications</h2>
+              <p>Choose the ways Ivy keeps you posted about policy updates, important reminders, and special programs.</p>
+            </header>
+            <div class="preference-list">
+              <article class="preference-item">
+                <div class="preference-copy">
+                  <h3>Email notifications</h3>
+                  <p>Receive coverage updates, monthly summaries, and digital statements.</p>
+                </div>
+                <label class="toggle" for="notifyEmail">
+                  <input type="checkbox" id="notifyEmail" data-storage="notifyEmail" checked>
+                  <span class="toggle-control" aria-hidden="true"></span>
+                </label>
+              </article>
+              <article class="preference-item">
+                <div class="preference-copy">
+                  <h3>Mobile push</h3>
+                  <p>Be alerted instantly when there is new activity or a claim status change.</p>
+                </div>
+                <label class="toggle" for="notifyPush">
+                  <input type="checkbox" id="notifyPush" data-storage="notifyPush" checked>
+                  <span class="toggle-control" aria-hidden="true"></span>
+                </label>
+              </article>
+              <article class="preference-item">
+                <div class="preference-copy">
+                  <h3>Text messages</h3>
+                  <p>Get short reminders about payments and time-sensitive appointments.</p>
+                </div>
+                <label class="toggle" for="notifySMS">
+                  <input type="checkbox" id="notifySMS" data-storage="notifySMS" checked>
+                  <span class="toggle-control" aria-hidden="true"></span>
+                </label>
+              </article>
+              <article class="preference-item">
+                <div class="preference-copy">
+                  <h3>Monthly recap</h3>
+                  <p>Receive a once-a-month digest covering benefits usage and healthy living tips.</p>
+                </div>
+                <label class="toggle" for="notifySummary">
+                  <input type="checkbox" id="notifySummary" data-storage="notifySummary">
+                  <span class="toggle-control" aria-hidden="true"></span>
+                </label>
+              </article>
+            </div>
+            <div class="panel-actions">
+              <button class="button outline-button" type="button" data-action="resetNotifications">Reset</button>
+              <button class="button solid-button" type="button" id="saveNotifications">Save changes</button>
+            </div>
+          </section>
+
+          <section id="privacyPanel" class="settings-panel" role="tabpanel" aria-labelledby="tabPrivacy" tabindex="0">
+            <header class="panel-header">
+              <h2 id="privacyTitle">Privacy &amp; Security</h2>
+              <p>Set up secure sign-in options and decide how Ivy protects your account.</p>
+            </header>
+            <div class="security-grid">
+              <article class="security-item">
+                <div>
+                  <h3>Password</h3>
+                  <p>Update your password at least every 90 days to keep your details safe.</p>
+                </div>
+                <div class="item-actions">
+                  <span class="status-pill neutral">Last changed 54 days ago</span>
+                  <button class="button ghost-button" type="button" data-action="openPasswordModal">Change</button>
+                </div>
+              </article>
+              <article class="security-item">
+                <div>
+                  <h3>Two-factor authentication</h3>
+                  <p>Use a one-time code whenever you sign in on a new device.</p>
+                </div>
+                <div class="item-actions">
+                  <span class="status-pill" data-twofa-status>Disabled</span>
+                  <button class="button solid-button" type="button" data-action="toggleTwoFA">Enable</button>
+                </div>
+              </article>
+              <article class="security-item">
+                <div>
+                  <h3>Login alerts</h3>
+                  <p>Get alerted if someone signs in from an unrecognized browser.</p>
+                </div>
+                <label class="toggle" for="loginAlerts">
+                  <input type="checkbox" id="loginAlerts" data-storage="loginAlerts" data-auto-save="true" checked>
+                  <span class="toggle-control" aria-hidden="true"></span>
+                </label>
+              </article>
+            </div>
+          </section>
+
+          <section id="dataPanel" class="settings-panel" role="tabpanel" aria-labelledby="tabData" tabindex="0">
+            <header class="panel-header">
+              <h2 id="dataTitle">Data &amp; Privacy</h2>
+              <p>Download the information we store for you or manage requests to remove data.</p>
+            </header>
+            <div class="data-grid">
+              <article class="data-item">
+                <div>
+                  <h3>Download my data</h3>
+                  <p>Receive a secure link with your claims, documents, and communications history.</p>
+                </div>
+                <button class="button solid-button" type="button" data-action="downloadData">Send download</button>
+              </article>
+              <article class="data-item">
+                <div>
+                  <h3>Export statements</h3>
+                  <p>Request PDF statements for your records and yearly tax filings.</p>
+                </div>
+                <button class="button ghost-button" type="button" data-action="exportStatements">Export</button>
+              </article>
+              <article class="data-item danger">
+                <div>
+                  <h3>Delete my account</h3>
+                  <p>This permanently removes your information after a 30-day review period.</p>
+                </div>
+                <button class="button danger-button" type="button" data-action="deleteAccount">Request removal</button>
+              </article>
+            </div>
+          </section>
         </div>
-        <div class="option-row">
-          <span>Remove My Account</span>
-          <button id="deleteAccount" class="danger">Delete</button>
-        </div>
-      </section>
+      </div>
     </main>
+  </div>
+
+  <div class="modal" id="passwordModal" role="dialog" aria-modal="true" aria-labelledby="passwordModalTitle" hidden>
+    <div class="modal-card">
+      <header class="modal-header">
+        <div>
+          <span class="eyebrow">Security</span>
+          <h2 id="passwordModalTitle">Change password</h2>
+          <p>Choose a unique password that you have not used elsewhere.</p>
+        </div>
+        <button class="modal-close" type="button" data-action="closePasswordModal" aria-label="Close dialog">&times;</button>
+      </header>
+      <form id="passwordForm" class="modal-form">
+        <label class="modal-field" for="currentPassword">
+          <span>Current password</span>
+          <input type="password" id="currentPassword" name="currentPassword" required autocomplete="current-password">
+        </label>
+        <label class="modal-field" for="newPassword">
+          <span>New password</span>
+          <input type="password" id="newPassword" name="newPassword" minlength="8" required autocomplete="new-password">
+        </label>
+        <label class="modal-field" for="confirmPassword">
+          <span>Confirm new password</span>
+          <input type="password" id="confirmPassword" name="confirmPassword" minlength="8" required autocomplete="new-password">
+        </label>
+        <p class="password-hint">Use at least 8 characters with a mix of numbers, letters, and symbols.</p>
+        <div class="panel-actions">
+          <button class="button outline-button" type="button" data-action="closePasswordModal">Cancel</button>
+          <button class="button solid-button" type="submit">Save password</button>
+        </div>
+      </form>
+    </div>
   </div>
   <script src="settings.js"></script>
 </body>

--- a/settings.js
+++ b/settings.js
@@ -1,64 +1,217 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const notifKeys = ['emailNotif', 'pushNotif', 'smsNotif'];
+const STORAGE_PREFIX = 'ivy-settings-';
 
-  notifKeys.forEach(key => {
-    const checkbox = document.getElementById(key);
-    if (checkbox) {
-      const stored = localStorage.getItem(key);
-      checkbox.checked = stored === 'true';
+function buildStorageKey(input) {
+  return `${STORAGE_PREFIX}${input.dataset.storage}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const panels = document.querySelectorAll('.settings-panel');
+  const navButtons = document.querySelectorAll('.settings-nav .nav-link');
+  const toggleInputs = document.querySelectorAll('input[data-storage]');
+
+  panels.forEach(panel => {
+    if (!panel.classList.contains('active')) {
+      panel.setAttribute('hidden', 'hidden');
     }
   });
 
-  const saveBtn = document.getElementById('saveNotifs');
-  if (saveBtn) {
-    saveBtn.addEventListener('click', () => {
-      notifKeys.forEach(key => {
-        const checkbox = document.getElementById(key);
-        if (checkbox) {
-          localStorage.setItem(key, checkbox.checked);
+  navButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      if (button.classList.contains('active')) return;
+
+      navButtons.forEach(other => {
+        const isActive = other === button;
+        other.classList.toggle('active', isActive);
+        other.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+
+      panels.forEach(panel => {
+        if (panel.id === button.dataset.target) {
+          panel.classList.add('active');
+          panel.removeAttribute('hidden');
+        } else {
+          panel.classList.remove('active');
+          panel.setAttribute('hidden', 'hidden');
         }
       });
-      alert('Notification settings saved');
+    });
+  });
+
+  toggleInputs.forEach(input => {
+    const key = buildStorageKey(input);
+    const storedValue = localStorage.getItem(key);
+    const fallback = input.defaultChecked ? 'true' : 'false';
+    const resolved = storedValue ?? fallback;
+
+    input.checked = resolved === 'true';
+    input.dataset.saved = resolved;
+
+    if (input.dataset.autoSave === 'true') {
+      input.addEventListener('change', () => {
+        localStorage.setItem(key, String(input.checked));
+        input.dataset.saved = String(input.checked);
+      });
+    }
+  });
+
+  const notificationsPanel = document.getElementById('notificationsPanel');
+  const notificationInputs = notificationsPanel
+    ? notificationsPanel.querySelectorAll('input[data-storage]')
+    : [];
+  const saveNotifications = document.getElementById('saveNotifications');
+  const resetNotifications = document.querySelector('[data-action="resetNotifications"]');
+
+  if (saveNotifications) {
+    saveNotifications.addEventListener('click', () => {
+      notificationInputs.forEach(input => {
+        const key = buildStorageKey(input);
+        localStorage.setItem(key, String(input.checked));
+        input.dataset.saved = String(input.checked);
+      });
+
+      window.alert('Notification preferences saved.');
     });
   }
 
-  const changePassword = document.getElementById('changePassword');
-  if (changePassword) {
-    changePassword.addEventListener('click', () => {
-      alert('Password change link sent to your email.');
+  if (resetNotifications) {
+    resetNotifications.addEventListener('click', () => {
+      notificationInputs.forEach(input => {
+        const saved = input.dataset.saved ?? 'false';
+        input.checked = saved === 'true';
+      });
     });
   }
 
-  const toggle2FA = document.getElementById('toggle2FA');
-  function update2FABtn() {
-    if (!toggle2FA) return;
-    const enabled = localStorage.getItem('twoFA') === 'true';
-    toggle2FA.textContent = enabled ? 'Disable' : 'Enable';
-  }
-  if (toggle2FA) {
-    update2FABtn();
-    toggle2FA.addEventListener('click', () => {
-      const enabled = localStorage.getItem('twoFA') === 'true';
-      localStorage.setItem('twoFA', !enabled);
-      update2FABtn();
-      alert(`Two-factor authentication ${!enabled ? 'enabled' : 'disabled'}`);
-    });
+  const twoFAButton = document.querySelector('[data-action="toggleTwoFA"]');
+  const twoFAStatus = document.querySelector('[data-twofa-status]');
+  const twoFAKey = `${STORAGE_PREFIX}twoFA`;
+
+  function updateTwoFAControls() {
+    const enabled = localStorage.getItem(twoFAKey) === 'true';
+
+    if (twoFAStatus) {
+      twoFAStatus.textContent = enabled ? 'Enabled' : 'Disabled';
+      twoFAStatus.classList.toggle('success', enabled);
+      twoFAStatus.classList.toggle('neutral', !enabled);
+    }
+
+    if (twoFAButton) {
+      twoFAButton.textContent = enabled ? 'Disable' : 'Enable';
+      twoFAButton.classList.toggle('outline-button', enabled);
+      twoFAButton.classList.toggle('solid-button', !enabled);
+    }
   }
 
-  const downloadData = document.getElementById('downloadData');
+  if (twoFAButton) {
+    if (!localStorage.getItem(twoFAKey)) {
+      localStorage.setItem(twoFAKey, 'false');
+    }
+
+    updateTwoFAControls();
+
+    twoFAButton.addEventListener('click', () => {
+      const enabled = localStorage.getItem(twoFAKey) === 'true';
+      localStorage.setItem(twoFAKey, String(!enabled));
+      updateTwoFAControls();
+      window.alert(`Two-factor authentication ${!enabled ? 'enabled' : 'disabled'}.`);
+    });
+  } else if (twoFAStatus) {
+    updateTwoFAControls();
+  }
+
+  const downloadData = document.querySelector('[data-action="downloadData"]');
   if (downloadData) {
     downloadData.addEventListener('click', () => {
-      alert('Downloading your data...');
+      window.alert('We will email you a secure link with your data shortly.');
     });
   }
 
-  const deleteAccount = document.getElementById('deleteAccount');
+  const exportStatements = document.querySelector('[data-action="exportStatements"]');
+  if (exportStatements) {
+    exportStatements.addEventListener('click', () => {
+      window.alert('Statement export requested. We will notify you when the files are ready.');
+    });
+  }
+
+  const deleteAccount = document.querySelector('[data-action="deleteAccount"]');
   if (deleteAccount) {
     deleteAccount.addEventListener('click', () => {
-      if (confirm('Are you sure you want to delete your account?')) {
+      const confirmed = window.confirm(
+        'Request account deletion? This begins a 30-day review before data is permanently removed.'
+      );
+
+      if (confirmed) {
         localStorage.clear();
-        alert('Account removed');
+        window.alert('Your deletion request has been submitted. A specialist will contact you shortly.');
       }
     });
   }
+
+  const passwordModal = document.getElementById('passwordModal');
+  const passwordForm = document.getElementById('passwordForm');
+  const openPasswordButtons = document.querySelectorAll('[data-action="openPasswordModal"]');
+  const closePasswordButtons = document.querySelectorAll('[data-action="closePasswordModal"]');
+
+  function openPasswordModal() {
+    if (!passwordModal) return;
+    passwordModal.removeAttribute('hidden');
+    passwordModal.classList.add('open');
+    document.body.classList.add('modal-open');
+    const currentField = passwordForm?.querySelector('input[name="currentPassword"]');
+    if (currentField) {
+      currentField.focus();
+    }
+  }
+
+  function closePasswordModal() {
+    if (!passwordModal) return;
+    passwordModal.classList.remove('open');
+    passwordModal.setAttribute('hidden', 'hidden');
+    document.body.classList.remove('modal-open');
+    passwordForm?.reset();
+  }
+
+  openPasswordButtons.forEach(button => {
+    button.addEventListener('click', openPasswordModal);
+  });
+
+  closePasswordButtons.forEach(button => {
+    button.addEventListener('click', closePasswordModal);
+  });
+
+  if (passwordModal) {
+    passwordModal.addEventListener('click', event => {
+      if (event.target === passwordModal) {
+        closePasswordModal();
+      }
+    });
+  }
+
+  if (passwordForm) {
+    passwordForm.addEventListener('submit', event => {
+      event.preventDefault();
+      const current = passwordForm.currentPassword.value.trim();
+      const next = passwordForm.newPassword.value.trim();
+      const confirmPassword = passwordForm.confirmPassword.value.trim();
+
+      if (!current || !next || !confirmPassword) {
+        window.alert('Please complete every password field.');
+        return;
+      }
+
+      if (next !== confirmPassword) {
+        window.alert('New password and confirmation must match.');
+        return;
+      }
+
+      window.alert('Your password has been updated.');
+      closePasswordModal();
+    });
+  }
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && passwordModal?.classList.contains('open')) {
+      closePasswordModal();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- redesign the settings page with a hero overview, category navigation, and enriched sections for notifications, privacy, and data management
- expand dashboard styles with shared button treatments, a settings layout system, responsive toggles, and modal presentation
- rebuild settings logic to power tab switching, preference persistence, two-factor controls, and the password change workflow

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3c16f2fbc83278755301aa2b8abe1