### PR TITLE
Add business overview dashboard layout

### DIFF
--- a/business-dashboard.html
+++ b/business-dashboard.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard - Business Overview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="dashboard.css" />
+  </head>
+  <body>
+    <div class="dashboard dashboard--enterprise">
+      <aside class="sidebar sidebar--enterprise">
+        <div class="enterprise-brand">
+          <div class="enterprise-brand__icon" aria-hidden="true">LB</div>
+          <div class="enterprise-brand__text">
+            <span class="enterprise-brand__label">LegacyBridge</span>
+            <span class="enterprise-brand__sub">Employer Portal</span>
+          </div>
+        </div>
+        <nav class="menu enterprise-menu">
+          <a class="active" href="#">Overview</a>
+          <a href="#">Plans &amp; Billing</a>
+          <a href="#">Support</a>
+          <a href="#">Settings</a>
+        </nav>
+        <div class="sidebar-bottom enterprise-sidebar-bottom">
+          <button class="logout">Log Out</button>
+          <div class="lang">
+            <button class="active">English</button>
+            <button>Español</button>
+          </div>
+        </div>
+      </aside>
+      <main class="main-content main-content--enterprise">
+        <header class="page-heading page-heading--enterprise">
+          <p class="breadcrumb">Dashboard • Overview</p>
+          <h1>
+            Welcome back,
+            <span class="page-heading__highlight">LegacyBridge</span>
+          </h1>
+          <p class="page-heading__subtitle">
+            You&apos;re all caught up. Review the latest plan insights or invite
+            new team members to keep everyone covered.
+          </p>
+        </header>
+        <section class="enterprise-status">
+          <div class="metrics-card">
+            <div class="metrics-card__heading">
+              <span>Plan Status</span>
+              <span class="status-pill status-pill--active">Active</span>
+            </div>
+            <p class="metrics-card__detail">Coverage renewed Apr 18, 2025</p>
+          </div>
+          <div class="metrics-card">
+            <div class="metrics-card__heading">
+              <span>Total Coverage</span>
+              <span class="status-pill">Up to $150,000</span>
+            </div>
+            <p class="metrics-card__detail">Across medical, vision &amp; dental</p>
+          </div>
+          <div class="metrics-card">
+            <div class="metrics-card__heading">
+              <span>Next Payment</span>
+              <span class="status-pill">May 01, 2025</span>
+            </div>
+            <p class="metrics-card__detail">Auto pay scheduled via ACH</p>
+          </div>
+        </section>
+        <section class="enterprise-actions">
+          <button class="enterprise-action">Add employees</button>
+          <button class="enterprise-action">View headcount</button>
+          <button class="enterprise-action">Update payment</button>
+          <button class="enterprise-action">Manage alerts</button>
+        </section>
+        <section class="enterprise-banner">
+          <div class="enterprise-banner__content">
+            <h2>Human-centered benefits for your team.</h2>
+            <p class="enterprise-banner__meta">©2025 MallowCare — Privacy Policy</p>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/dashboard.css
+++ b/dashboard.css
@@ -47,6 +47,10 @@ button {
   background: var(--color-background);
 }
 
+.dashboard--enterprise {
+  background: var(--color-background);
+}
+
 .sidebar {
   width: 280px;
   background: linear-gradient(180deg, #d8b86a 0%, #f5e6c7 100%);
@@ -57,6 +61,80 @@ button {
   gap: 2rem;
   padding: 2.5rem 2rem;
   box-shadow: inset -1px 0 0 rgba(22, 60, 48, 0.12);
+}
+
+.sidebar--enterprise {
+  background: linear-gradient(180deg, #143d31 0%, #1f4f41 100%);
+  color: #f5fbf8;
+  box-shadow: inset -1px 0 0 rgba(12, 35, 28, 0.2);
+}
+
+.enterprise-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.enterprise-brand__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.enterprise-brand__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(245, 251, 248, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #f9f5e3;
+  box-shadow: inset 0 0 0 2px rgba(249, 245, 227, 0.35),
+    0 12px 20px rgba(6, 22, 17, 0.35);
+}
+
+.enterprise-brand__label {
+  font-size: 1.25rem;
+  font-weight: 700;
+  display: block;
+}
+
+.enterprise-brand__sub {
+  font-size: 0.85rem;
+  color: rgba(245, 251, 248, 0.7);
+}
+
+.enterprise-menu a {
+  color: rgba(245, 251, 248, 0.86);
+}
+
+.enterprise-menu a.active {
+  background: rgba(249, 245, 227, 0.18);
+  color: #f9f5e3;
+}
+
+.enterprise-sidebar-bottom .logout {
+  background: rgba(249, 245, 227, 0.12);
+  color: #f9f5e3;
+  border: 1px solid rgba(249, 245, 227, 0.25);
+}
+
+.enterprise-sidebar-bottom .logout:hover {
+  box-shadow: 0 18px 36px rgba(6, 22, 17, 0.35);
+}
+
+.enterprise-sidebar-bottom .lang button {
+  color: rgba(245, 251, 248, 0.85);
+  border-color: rgba(249, 245, 227, 0.3);
+}
+
+.enterprise-sidebar-bottom .lang button.active,
+.enterprise-sidebar-bottom .lang button:hover {
+  background: rgba(249, 245, 227, 0.18);
+  color: #f9f5e3;
 }
 
 .profile {
@@ -160,6 +238,11 @@ button {
   gap: 2rem;
 }
 
+.main-content--enterprise {
+  background: var(--color-background);
+  gap: 2.5rem;
+}
+
 .main-content h1 {
   margin: 0;
   font-size: clamp(2rem, 3vw, 2.6rem);
@@ -174,6 +257,109 @@ button {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.page-heading--enterprise h1 {
+  font-size: clamp(2.2rem, 3vw, 2.8rem);
+}
+
+.page-heading__highlight {
+  color: var(--color-forest-700);
+}
+
+.page-heading--enterprise .page-heading__subtitle {
+  max-width: 600px;
+}
+
+.enterprise-status {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.metrics-card {
+  background: #fff;
+  border-radius: var(--radius-medium);
+  padding: 1.5rem;
+  box-shadow: 0 24px 40px rgba(17, 40, 32, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.metrics-card__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.metrics-card__detail {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.status-pill {
+  background: rgba(31, 87, 72, 0.12);
+  color: var(--color-forest-700);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.status-pill--active {
+  background: rgba(62, 198, 147, 0.16);
+  color: #137b51;
+}
+
+.enterprise-actions {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.enterprise-action {
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.2rem;
+  background: var(--color-forest-900);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.enterprise-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(17, 40, 32, 0.18);
+}
+
+.enterprise-banner {
+  background: linear-gradient(120deg, #1f4f41 0%, #0f3328 100%);
+  border-radius: var(--radius-large);
+  padding: clamp(2.25rem, 4vw, 3.5rem);
+  color: #f5fbf8;
+  box-shadow: 0 30px 50px rgba(12, 35, 28, 0.35);
+}
+
+.enterprise-banner h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.enterprise-banner__content {
+  max-width: 520px;
+}
+
+.enterprise-banner__meta {
+  margin: 0.75rem 0 0;
+  color: rgba(245, 251, 248, 0.7);
+  font-size: 0.9rem;
 }
 
 .page-heading__subtitle {


### PR DESCRIPTION
## Summary
- add a business overview dashboard page for employers with welcome messaging, status cards, and quick actions
- extend shared dashboard styles with enterprise theming, metric cards, and banner treatments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3c23aa03c8327a45d56fa56cfa8a7