### PR TITLE
Add business profile overview and edit dashboard

### DIFF
--- a/business-profile.html
+++ b/business-profile.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard - Business Profile</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <div class="dashboard business-dashboard">
+    <aside class="sidebar sidebar--business" aria-label="Workspace navigation">
+      <div class="company-summary">
+        <div class="company-avatar" aria-hidden="true">SB</div>
+        <h1>Spacebridge</h1>
+        <p class="company-plan">Business Protect · 48 seats</p>
+        <p class="company-renewal">Renewal in 14 days</p>
+      </div>
+      <nav class="menu menu--business" aria-label="Primary">
+        <p class="menu-label">Workspace</p>
+        <a href="#" class="active">Overview</a>
+        <a href="#">Business Profile</a>
+        <a href="#">Team Access</a>
+        <a href="#">Verification</a>
+        <a href="#">Billing</a>
+        <a href="#">Support</a>
+      </nav>
+      <div class="sidebar-bottom sidebar-bottom--business">
+        <div class="support-card">
+          <p>Need a hand with onboarding?</p>
+          <button class="business-button business-button--ghost" type="button">Contact Support</button>
+        </div>
+        <button class="logout logout--business" type="button">Sign Out</button>
+      </div>
+    </aside>
+
+    <main class="business-main" data-view="overview">
+      <div class="breadcrumb">Overview · Business Profile</div>
+      <header class="business-header">
+        <div>
+          <h2 class="business-eyebrow">Business Workspace</h2>
+          <h1>Business Profile</h1>
+          <p class="business-subtitle">Keep your company contact details, verification records, and language preferences current so employees have uninterrupted coverage.</p>
+          <div class="business-header__meta">
+            <span class="business-badge">Last updated 2 days ago</span>
+            <span class="business-badge business-badge--success">Status: Verified</span>
+          </div>
+        </div>
+        <div class="business-header__actions">
+          <button id="businessViewToggle" class="business-button business-button--primary" type="button">Edit details</button>
+        </div>
+      </header>
+
+      <section class="business-panel is-active" data-business-panel="overview" aria-labelledby="overview-heading">
+        <h2 id="overview-heading" class="sr-only">Overview</h2>
+        <div class="business-grid">
+          <article class="business-card business-card--full">
+            <div class="business-card__header">
+              <div>
+                <h3>Contact Information</h3>
+                <p>Primary company details used for communications, billing, and compliance notifications.</p>
+              </div>
+              <button class="business-button business-button--ghost" type="button">Download summary</button>
+            </div>
+            <dl class="info-grid">
+              <div class="info-item">
+                <dt>Company name</dt>
+                <dd>Spacebridge Studio LLC</dd>
+              </div>
+              <div class="info-item">
+                <dt>Primary contact</dt>
+                <dd>Ana Velásquez</dd>
+              </div>
+              <div class="info-item">
+                <dt>Work email</dt>
+                <dd>ana.velasquez@spacebridge.co</dd>
+              </div>
+              <div class="info-item">
+                <dt>Work phone</dt>
+                <dd>+1 (305) 555-9823</dd>
+              </div>
+              <div class="info-item">
+                <dt>Headquarters</dt>
+                <dd>8290 NW 27th Street, Suite 400 · Doral, FL 33122</dd>
+              </div>
+              <div class="info-item">
+                <dt>Tax ID (EIN)</dt>
+                <dd>65-9182034</dd>
+              </div>
+              <div class="info-item">
+                <dt>Employees covered</dt>
+                <dd>48 active · 12 pending invitations</dd>
+              </div>
+              <div class="info-item">
+                <dt>Billing cadence</dt>
+                <dd>Monthly on the 15th</dd>
+              </div>
+            </dl>
+            <footer class="business-card__footer">
+              <p>Need to make updates? Switch to edit mode or email <a href="mailto:support@mallowcare.com">support@mallowcare.com</a>.</p>
+            </footer>
+          </article>
+
+          <article class="business-card">
+            <div class="business-card__header">
+              <div>
+                <h3>Verification Documents</h3>
+                <p>Keep required documents current to maintain uninterrupted employee benefits.</p>
+              </div>
+              <button class="business-button business-button--ghost" type="button">Manage documents</button>
+            </div>
+            <ul class="document-list" aria-label="Verification documents">
+              <li class="document-item">
+                <div class="document-item__details">
+                  <h4>Articles of Incorporation</h4>
+                  <p>Uploaded Feb 12, 2025</p>
+                </div>
+                <span class="status-pill status-success">Approved</span>
+                <button class="business-button business-button--ghost" type="button">View</button>
+              </li>
+              <li class="document-item">
+                <div class="document-item__details">
+                  <h4>IRS Form W-9</h4>
+                  <p>Uploaded Jan 28, 2025</p>
+                </div>
+                <span class="status-pill status-warning">In Review</span>
+                <button class="business-button business-button--ghost" type="button">View</button>
+              </li>
+              <li class="document-item">
+                <div class="document-item__details">
+                  <h4>Beneficiary Policy</h4>
+                  <p>Requested Mar 04, 2025</p>
+                </div>
+                <span class="status-pill status-pending">Requested</span>
+                <button class="business-button business-button--ghost" type="button">Upload</button>
+              </li>
+              <li class="document-item">
+                <div class="document-item__details">
+                  <h4>State Registration</h4>
+                  <p>Uploaded Nov 20, 2024</p>
+                </div>
+                <span class="status-pill status-success">Approved</span>
+                <button class="business-button business-button--ghost" type="button">View</button>
+              </li>
+            </ul>
+          </article>
+
+          <article class="business-card">
+            <div class="business-card__header">
+              <div>
+                <h3>Language Preference</h3>
+                <p>Control how plan updates and onboarding resources appear for your team.</p>
+              </div>
+            </div>
+            <p class="language-selected"><strong>Primary language:</strong> <span data-language-display>English (US)</span></p>
+            <div class="language-options" role="group" aria-label="Language preference">
+              <button class="business-chip is-selected" type="button" data-language-option="en">English</button>
+              <button class="business-chip" type="button" data-language-option="es">Español</button>
+              <button class="business-chip" type="button" data-language-option="pt">Português</button>
+            </div>
+            <p class="business-card__footnote">Team notifications and billing reminders will use this language.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="business-panel" data-business-panel="edit" aria-labelledby="edit-heading">
+        <h2 id="edit-heading" class="sr-only">Edit details</h2>
+        <div class="business-grid">
+          <article class="business-card business-card--full">
+            <form id="businessContactForm" class="business-form" autocomplete="on">
+              <div class="business-card__header">
+                <div>
+                  <h3>Contact Information</h3>
+                  <p>Update core business details so your benefits never miss an important update.</p>
+                </div>
+              </div>
+              <div class="form-grid">
+                <label class="form-field">
+                  <span>Company name</span>
+                  <input type="text" name="companyName" value="Spacebridge Studio LLC" autocomplete="organization" required>
+                </label>
+                <label class="form-field">
+                  <span>Primary contact</span>
+                  <input type="text" name="primaryContact" value="Ana Velásquez" autocomplete="name" required>
+                </label>
+                <label class="form-field">
+                  <span>Work email</span>
+                  <input type="email" name="workEmail" value="ana.velasquez@spacebridge.co" autocomplete="email" required>
+                </label>
+                <label class="form-field">
+                  <span>Work phone</span>
+                  <input type="tel" name="workPhone" value="+1 (305) 555-9823" autocomplete="tel" required>
+                </label>
+                <label class="form-field">
+                  <span>Headquarters street</span>
+                  <input type="text" name="hqStreet" value="8290 NW 27th Street" autocomplete="street-address" required>
+                </label>
+                <label class="form-field">
+                  <span>Suite or unit</span>
+                  <input type="text" name="hqUnit" value="Suite 400" autocomplete="address-line2">
+                </label>
+                <label class="form-field">
+                  <span>City</span>
+                  <input type="text" name="hqCity" value="Doral" autocomplete="address-level2" required>
+                </label>
+                <label class="form-field">
+                  <span>State</span>
+                  <input type="text" name="hqState" value="FL" autocomplete="address-level1" required>
+                </label>
+                <label class="form-field">
+                  <span>Postal code</span>
+                  <input type="text" name="hqPostal" value="33122" autocomplete="postal-code" required>
+                </label>
+                <label class="form-field">
+                  <span>Tax ID (EIN)</span>
+                  <input type="text" name="taxId" value="65-9182034" autocomplete="off" required>
+                </label>
+                <label class="form-field">
+                  <span>Employees covered</span>
+                  <input type="number" name="employeesCovered" value="48" min="0" required>
+                </label>
+                <label class="form-field">
+                  <span>Billing cadence</span>
+                  <select name="billingCadence" required>
+                    <option value="monthly" selected>Monthly on the 15th</option>
+                    <option value="quarterly">Quarterly on the 1st</option>
+                    <option value="annually">Annually on enrollment date</option>
+                  </select>
+                </label>
+              </div>
+              <div class="form-actions">
+                <button class="business-button business-button--ghost" type="button" data-action="cancel">Cancel</button>
+                <button class="business-button business-button--primary" type="submit">Save changes</button>
+              </div>
+            </form>
+          </article>
+
+          <article class="business-card">
+            <form id="businessDocumentsForm" class="business-form">
+              <div class="business-card__header">
+                <div>
+                  <h3>Verification Documents</h3>
+                  <p>Upload refreshed documentation or update review statuses from your compliance workspace.</p>
+                </div>
+                <button class="business-button business-button--ghost" type="button">Add document</button>
+              </div>
+              <div class="document-editor">
+                <div class="document-editor__row">
+                  <div class="document-editor__details">
+                    <h4>Articles of Incorporation</h4>
+                    <p>PDF · Last uploaded Feb 12, 2025</p>
+                  </div>
+                  <div class="document-editor__status">
+                    <label>
+                      <span>Status</span>
+                      <select name="docArticles" data-status-pill="docArticles">
+                        <option value="approved" selected>Approved</option>
+                        <option value="review">In Review</option>
+                        <option value="requested">Requested</option>
+                      </select>
+                    </label>
+                    <span class="status-pill status-success" data-status-pill-target="docArticles">Approved</span>
+                  </div>
+                  <div class="document-editor__actions">
+                    <button class="business-button business-button--ghost" type="button">Upload new</button>
+                  </div>
+                </div>
+                <div class="document-editor__row">
+                  <div class="document-editor__details">
+                    <h4>IRS Form W-9</h4>
+                    <p>PDF · Last uploaded Jan 28, 2025</p>
+                  </div>
+                  <div class="document-editor__status">
+                    <label>
+                      <span>Status</span>
+                      <select name="docW9" data-status-pill="docW9">
+                        <option value="approved">Approved</option>
+                        <option value="review" selected>In Review</option>
+                        <option value="requested">Requested</option>
+                      </select>
+                    </label>
+                    <span class="status-pill status-warning" data-status-pill-target="docW9">In Review</span>
+                  </div>
+                  <div class="document-editor__actions">
+                    <button class="business-button business-button--ghost" type="button">Upload new</button>
+                  </div>
+                </div>
+                <div class="document-editor__row">
+                  <div class="document-editor__details">
+                    <h4>Beneficiary Policy</h4>
+                    <p>None on file · Requested Mar 04, 2025</p>
+                  </div>
+                  <div class="document-editor__status">
+                    <label>
+                      <span>Status</span>
+                      <select name="docPolicy" data-status-pill="docPolicy">
+                        <option value="approved">Approved</option>
+                        <option value="review">In Review</option>
+                        <option value="requested" selected>Requested</option>
+                      </select>
+                    </label>
+                    <span class="status-pill status-pending" data-status-pill-target="docPolicy">Requested</span>
+                  </div>
+                  <div class="document-editor__actions">
+                    <button class="business-button business-button--primary" type="button">Request upload</button>
+                  </div>
+                </div>
+              </div>
+              <div class="form-actions">
+                <button class="business-button business-button--ghost" type="button" data-action="cancel">Cancel</button>
+                <button class="business-button business-button--primary" type="submit">Save updates</button>
+              </div>
+            </form>
+          </article>
+
+          <article class="business-card">
+            <form id="businessLanguageForm" class="business-form">
+              <div class="business-card__header">
+                <div>
+                  <h3>Language Preference</h3>
+                  <p>Select the default language for notifications and onboarding.</p>
+                </div>
+              </div>
+              <div class="form-grid single-column">
+                <label class="form-field">
+                  <span>Preferred language</span>
+                  <select id="languageSelect" name="preferredLanguage">
+                    <option value="en" selected>English (US)</option>
+                    <option value="es">Español (LatAm)</option>
+                    <option value="pt">Português (Brasil)</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Internal notes</span>
+                  <textarea name="languageNotes" rows="3" placeholder="Share context for our onboarding team"></textarea>
+                </label>
+              </div>
+              <div class="form-actions">
+                <button class="business-button business-button--ghost" type="button" data-action="cancel">Cancel</button>
+                <button class="business-button business-button--primary" type="submit">Update preference</button>
+              </div>
+            </form>
+          </article>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script src="business-profile.js"></script>
+</body>
+</html>

--- a/business-profile.js
+++ b/business-profile.js
@@ -1,0 +1,139 @@
+const STATUS_MAP = {
+  approved: { label: 'Approved', className: 'status-success' },
+  review: { label: 'In Review', className: 'status-warning' },
+  requested: { label: 'Requested', className: 'status-pending' }
+};
+
+const LANGUAGE_DATA = {
+  en: { label: 'English (US)', button: 'English' },
+  es: { label: 'Español (LatAm)', button: 'Español' },
+  pt: { label: 'Português (Brasil)', button: 'Português' }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const main = document.querySelector('.business-main');
+  if (!main) return;
+
+  const viewToggle = document.getElementById('businessViewToggle');
+  const panels = Array.from(document.querySelectorAll('[data-business-panel]'));
+
+  const setView = view => {
+    const nextView = view === 'edit' ? 'edit' : 'overview';
+    main.dataset.view = nextView;
+    panels.forEach(panel => {
+      panel.classList.toggle('is-active', panel.dataset.businessPanel === nextView);
+    });
+
+    if (viewToggle) {
+      if (nextView === 'edit') {
+        viewToggle.textContent = 'Back to overview';
+        viewToggle.classList.remove('business-button--primary');
+        viewToggle.classList.add('business-button--ghost');
+        viewToggle.setAttribute('aria-pressed', 'true');
+      } else {
+        viewToggle.textContent = 'Edit details';
+        viewToggle.classList.add('business-button--primary');
+        viewToggle.classList.remove('business-button--ghost');
+        viewToggle.setAttribute('aria-pressed', 'false');
+      }
+    }
+  };
+
+  setView(main.dataset.view || 'overview');
+
+  if (viewToggle) {
+    viewToggle.addEventListener('click', () => {
+      const current = main.dataset.view === 'edit' ? 'overview' : 'edit';
+      setView(current);
+    });
+  }
+
+  setupStatusPills();
+  setupForms(setView);
+  setupLanguageControls();
+});
+
+function setupStatusPills() {
+  const selects = document.querySelectorAll('select[data-status-pill]');
+  selects.forEach(select => {
+    const pill = document.querySelector(`[data-status-pill-target="${select.dataset.statusPill}"]`);
+    if (!pill) return;
+
+    const applyStatus = value => {
+      const status = STATUS_MAP[value] || STATUS_MAP.review;
+      pill.textContent = status.label;
+      pill.classList.remove('status-success', 'status-warning', 'status-pending');
+      pill.classList.add(status.className);
+    };
+
+    applyStatus(select.value);
+    select.addEventListener('change', () => applyStatus(select.value));
+  });
+}
+
+function setupForms(setView) {
+  const forms = document.querySelectorAll('.business-form');
+  forms.forEach(form => {
+    const cancelButton = form.querySelector('[data-action="cancel"]');
+    if (cancelButton) {
+      cancelButton.addEventListener('click', () => {
+        form.reset();
+        setView('overview');
+      });
+    }
+
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      if (form.id === 'businessLanguageForm') {
+        const select = form.querySelector('select[name="preferredLanguage"]');
+        if (select) {
+          updateLanguageDisplay(select.value);
+        }
+      }
+      alert('Business profile updated successfully.');
+      setView('overview');
+    });
+  });
+}
+
+function setupLanguageControls() {
+  const languageButtons = document.querySelectorAll('[data-language-option]');
+  const languageSelect = document.getElementById('languageSelect');
+
+  languageButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      const value = button.dataset.languageOption;
+      if (!value) {
+        return;
+      }
+      updateLanguageDisplay(value);
+      if (languageSelect) {
+        languageSelect.value = value;
+      }
+    });
+  });
+
+  if (languageSelect) {
+    updateLanguageDisplay(languageSelect.value);
+  }
+}
+
+function updateLanguageDisplay(code) {
+  const display = document.querySelector('[data-language-display]');
+  const buttons = document.querySelectorAll('[data-language-option]');
+  const data = LANGUAGE_DATA[code] || LANGUAGE_DATA.en;
+
+  if (display) {
+    display.textContent = data.label;
+  }
+
+  buttons.forEach(button => {
+    if (button.dataset.languageOption === code) {
+      button.classList.add('is-selected');
+      button.setAttribute('aria-pressed', 'true');
+    } else {
+      button.classList.remove('is-selected');
+      button.setAttribute('aria-pressed', 'false');
+    }
+  });
+}

--- a/dashboard.css
+++ b/dashboard.css
@@ -1461,3 +1461,541 @@ th {
 }
 
 
+
+/* Business workspace */
+.business-dashboard {
+  background: var(--color-background);
+}
+
+.sidebar--business {
+  background: linear-gradient(180deg, #0f2d24 0%, #174636 100%);
+  color: #f2f6f4;
+  box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.1);
+}
+
+.sidebar--business h1 {
+  margin: 1.5rem 0 0.35rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.sidebar--business .company-summary {
+  text-align: center;
+}
+
+.company-avatar {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.14);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: 0.12em;
+}
+
+.company-plan {
+  margin: 0.35rem 0 0;
+  font-weight: 600;
+  color: rgba(242, 246, 244, 0.82);
+}
+
+.company-renewal {
+  margin: 0.1rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(242, 246, 244, 0.7);
+}
+
+.menu--business {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.menu-label {
+  margin: 0.5rem 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(242, 246, 244, 0.65);
+  font-weight: 700;
+}
+
+.menu--business a {
+  color: rgba(242, 246, 244, 0.9);
+  font-weight: 600;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.menu--business a:hover {
+  background: rgba(8, 28, 22, 0.35);
+  transform: translateX(4px);
+}
+
+.menu--business a.active {
+  background: rgba(242, 246, 244, 0.18);
+  color: #fff;
+}
+
+.sidebar-bottom--business {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.support-card {
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: rgba(8, 28, 22, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.support-card p {
+  margin: 0;
+  color: rgba(242, 246, 244, 0.86);
+  font-weight: 600;
+}
+
+.logout--business {
+  background: rgba(242, 246, 244, 0.16);
+  color: #fff;
+  border: 1px solid rgba(242, 246, 244, 0.35);
+}
+
+.logout--business:hover {
+  background: rgba(242, 246, 244, 0.22);
+}
+
+.business-main {
+  flex: 1;
+  padding: 3rem clamp(2rem, 6vw, 4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  background: var(--color-background);
+}
+
+.business-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.business-eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-muted);
+}
+
+.business-header h1 {
+  margin: 0.35rem 0 0.65rem;
+  font-size: clamp(2.1rem, 3vw, 2.75rem);
+}
+
+.business-subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 620px;
+}
+
+.business-header__meta {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.business-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(22, 60, 48, 0.12);
+  color: var(--color-forest-900);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.business-badge--success {
+  background: rgba(31, 87, 72, 0.18);
+  color: var(--color-forest-900);
+}
+
+.business-header__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.business-button {
+  font: inherit;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.business-button--primary {
+  background: var(--color-forest-900);
+  color: #fff;
+}
+
+.business-button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(17, 40, 32, 0.18);
+}
+
+.business-button--ghost {
+  background: transparent;
+  color: var(--color-forest-900);
+  border-color: rgba(22, 60, 48, 0.2);
+}
+
+.business-button--ghost:hover {
+  background: rgba(22, 60, 48, 0.08);
+}
+
+.business-button:focus-visible {
+  outline: 3px solid rgba(31, 87, 72, 0.3);
+  outline-offset: 3px;
+}
+
+.business-panel {
+  display: none;
+}
+
+.business-panel.is-active {
+  display: block;
+}
+
+.business-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-content: start;
+}
+
+.business-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 26px 45px rgba(17, 40, 32, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 0;
+}
+
+.business-card--full {
+  grid-column: 1 / -1;
+}
+
+.business-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.business-card__header h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.4rem;
+}
+
+.business-card__header p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.business-card__footer {
+  margin-top: 0.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(22, 60, 48, 0.12);
+  color: var(--color-muted);
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.business-card__footer a {
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.business-card__footnote {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.info-grid {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.35rem 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.info-item dt {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.info-item dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--color-forest-900);
+}
+
+.document-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.document-item {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.document-item__details {
+  flex: 1 1 200px;
+}
+
+.document-item__details h4 {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+}
+
+.document-item__details p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.status-success {
+  background: #e4f3e8;
+  color: #1a7f52;
+}
+
+.status-warning {
+  background: #fff2d8;
+  color: #8a5b00;
+}
+
+.status-pending {
+  background: #fde1e1;
+  color: #b71c1c;
+}
+
+.business-card .status-pill {
+  font-size: 0.85rem;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.language-selected {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.language-options {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.business-chip {
+  border-radius: 999px;
+  border: 1px solid rgba(22, 60, 48, 0.18);
+  background: transparent;
+  padding: 0.45rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.business-chip:hover {
+  background: rgba(22, 60, 48, 0.08);
+}
+
+.business-chip.is-selected {
+  background: rgba(22, 60, 48, 0.16);
+  color: var(--color-forest-900);
+}
+
+.business-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.business-form .form-grid {
+  display: grid;
+  gap: 1.25rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.business-form .form-grid.single-column {
+  grid-template-columns: minmax(220px, 1fr);
+}
+
+.business-form .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.business-form .form-field span {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-forest-900);
+}
+
+.business-form input,
+.business-form select,
+.business-form textarea {
+  font: inherit;
+  color: inherit;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(22, 60, 48, 0.18);
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(17, 40, 32, 0.05) inset;
+}
+
+.business-form textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.business-form select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23163c30' d='M6 8L0 .5h12L6 8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 12px;
+  padding-right: 2.5rem;
+}
+
+.business-form input:focus,
+.business-form select:focus,
+.business-form textarea:focus {
+  outline: 3px solid rgba(31, 87, 72, 0.25);
+  outline-offset: 2px;
+}
+
+.document-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.document-editor__row {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: start;
+  padding: 1.25rem 0;
+  border-top: 1px solid rgba(22, 60, 48, 0.12);
+}
+
+.document-editor__row:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.document-editor__details h4 {
+  margin: 0 0 0.35rem;
+}
+
+.document-editor__details p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.document-editor__status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.document-editor__status label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.document-editor__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+@media (max-width: 1100px) {
+  .document-editor__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .document-editor__actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 780px) {
+  .business-header {
+    flex-direction: column;
+  }
+
+  .business-card__header {
+    flex-direction: column;
+  }
+
+  .document-editor__row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .business-main {
+    padding: 2.25rem 1.5rem 2.5rem;
+  }
+
+  .business-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- create a dedicated `business-profile.html` workspace with overview and edit cards for company contact, verification, and language information
- add `business-profile.js` to toggle between views, keep status pills in sync, and manage shared language preferences
- extend `dashboard.css` with business-specific sidebar, card, and form styling that supports both read-only and editable layouts

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d3c2a4ed9c8327a71204998afeecaa