### PR TITLE
Add business plans and billing experience

### DIFF
--- a/business-billing.js
+++ b/business-billing.js
@@ -1,0 +1,347 @@
+const STATUS_CONFIG = {
+  paid: { label: 'Paid', className: 'status-pill--success' },
+  processing: { label: 'Processing', className: 'status-pill--info' },
+  overdue: { label: 'Overdue', className: 'status-pill--danger' },
+  refunded: { label: 'Refunded', className: 'status-pill--warning' }
+};
+
+const BILLING_HISTORY = [
+  {
+    date: '2025-04-15',
+    invoice: 'INV-2098',
+    amount: 4820,
+    status: 'paid'
+  },
+  {
+    date: '2025-03-15',
+    invoice: 'INV-2086',
+    amount: 4820,
+    status: 'paid'
+  },
+  {
+    date: '2025-02-15',
+    invoice: 'INV-2072',
+    amount: 4795,
+    status: 'paid'
+  },
+  {
+    date: '2025-01-15',
+    invoice: 'INV-2059',
+    amount: 4795,
+    status: 'processing'
+  },
+  {
+    date: '2024-12-15',
+    invoice: 'INV-2041',
+    amount: 4750,
+    status: 'overdue'
+  },
+  {
+    date: '2024-11-15',
+    invoice: 'INV-2028',
+    amount: 4750,
+    status: 'paid'
+  }
+];
+
+const billingState = {
+  autopay: true,
+  summary: {
+    methodName: 'Corporate Visa',
+    cardholder: 'LegacyBridge Benefits',
+    cardNumber: '4321432143214321',
+    expiry: '11/27',
+    nextInvoiceDate: '2025-05-15',
+    invoiceAmount: 4820,
+    address: '4100 Market Street, Suite 1200 · Denver, CO 80205'
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const overviewSection = document.getElementById('billingOverview');
+  const formsSection = document.getElementById('billingForms');
+  const feedback = document.getElementById('billingFeedback');
+  const autopayButton = document.querySelector('[data-toggle-autopay]');
+  const autopayPills = document.querySelectorAll('[data-autopay-pill]');
+  const summaryMethod = document.querySelector('[data-summary-method]');
+  const summaryMeta = document.querySelector('[data-summary-meta]');
+  const summaryNext = document.querySelector('[data-summary-next]');
+  const summaryAddress = document.querySelector('[data-summary-address]');
+  const openFormButtons = document.querySelectorAll('[data-open-forms]');
+  const closeButtons = document.querySelectorAll('[data-close-forms]');
+  const editForm = document.getElementById('editBillingForm');
+  const addForm = document.getElementById('addBillingForm');
+  const historyBody = document.getElementById('billingHistoryBody');
+  const historySearch = document.getElementById('billingHistorySearch');
+
+  if (!overviewSection || !formsSection) {
+    return;
+  }
+
+  let feedbackTimeoutId;
+
+  renderSummary();
+  renderHistory();
+  updateAutopayUI(billingState.autopay);
+
+  openFormButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      const mode = button.dataset.openForms || 'edit';
+      openForms(mode);
+    });
+  });
+
+  closeButtons.forEach(button => {
+    button.addEventListener('click', () => {
+      closeForms();
+    });
+  });
+
+  if (autopayButton) {
+    autopayButton.addEventListener('click', () => {
+      billingState.autopay = !billingState.autopay;
+      updateAutopayUI(billingState.autopay);
+      const select = document.getElementById('editAutopay');
+      if (select) {
+        select.value = billingState.autopay ? 'enabled' : 'paused';
+      }
+      showFeedback(
+        billingState.autopay
+          ? 'Autopay resumed. Future invoices will process automatically.'
+          : 'Autopay paused. We will send reminders before each invoice.',
+        billingState.autopay ? 'success' : 'info'
+      );
+    });
+  }
+
+  if (editForm) {
+    editForm.addEventListener('submit', event => {
+      event.preventDefault();
+      const formData = new FormData(editForm);
+      billingState.summary.methodName = formData.get('method')?.toString().trim() || billingState.summary.methodName;
+      billingState.summary.cardholder = formData.get('cardholder')?.toString().trim() || billingState.summary.cardholder;
+      billingState.summary.cardNumber = sanitizeNumber(formData.get('cardNumber')) || billingState.summary.cardNumber;
+      billingState.summary.expiry = formData.get('expiry')?.toString().trim() || billingState.summary.expiry;
+      billingState.summary.nextInvoiceDate = formData.get('nextPayment') || billingState.summary.nextInvoiceDate;
+      const amountValue = parseFloat(formData.get('invoiceAmount'));
+      billingState.summary.invoiceAmount = Number.isFinite(amountValue)
+        ? amountValue
+        : billingState.summary.invoiceAmount;
+      billingState.summary.address = formData.get('billingAddress')?.toString().trim() || billingState.summary.address;
+      billingState.autopay = formData.get('autopay') !== 'paused';
+
+      renderSummary();
+      updateAutopayUI(billingState.autopay);
+      showFeedback('Payment method updated successfully.');
+      closeForms();
+    });
+  }
+
+  if (addForm) {
+    addForm.addEventListener('submit', event => {
+      event.preventDefault();
+      const formData = new FormData(addForm);
+      const label = (formData.get('method') || 'New payment method').toString().trim();
+      const usage = formData.get('preferredUsage');
+      showFeedback(
+        `Backup method "${label}" saved for ${describeUsage(usage)}.`,
+        'success'
+      );
+      addForm.reset();
+      closeForms();
+    });
+  }
+
+  if (historySearch) {
+    historySearch.addEventListener('input', () => {
+      renderHistory(historySearch.value);
+    });
+  }
+
+  if (historyBody) {
+    historyBody.addEventListener('click', event => {
+      const button = event.target.closest('[data-receipt]');
+      if (!button) return;
+      const invoiceId = button.dataset.receipt;
+      showFeedback(`Receipt for ${invoiceId} is downloading now.`, 'info');
+    });
+  }
+
+  function openForms(mode) {
+    formsSection.hidden = false;
+    overviewSection.hidden = true;
+    formsSection.dataset.mode = mode;
+    if (editForm) {
+      editForm.classList.toggle('is-active', mode === 'edit');
+    }
+    if (addForm) {
+      addForm.classList.toggle('is-active', mode === 'add');
+    }
+    if (mode === 'edit') {
+      prefillEditForm();
+      const focusTarget = editForm?.querySelector('input, select, textarea');
+      focusTarget?.focus();
+    } else if (mode === 'add') {
+      addForm?.reset();
+      const focusTarget = addForm?.querySelector('input, select, textarea');
+      focusTarget?.focus();
+    }
+    formsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function closeForms() {
+    formsSection.hidden = true;
+    overviewSection.hidden = false;
+    formsSection.dataset.mode = '';
+    if (editForm) {
+      editForm.classList.remove('is-active');
+    }
+    if (addForm) {
+      addForm.classList.remove('is-active');
+    }
+    overviewSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function renderSummary() {
+    const lastFour = getLastFour(billingState.summary.cardNumber);
+    if (summaryMethod) {
+      summaryMethod.textContent = `${billingState.summary.methodName} •••• ${lastFour}`;
+    }
+    if (summaryMeta) {
+      summaryMeta.textContent = `${billingState.summary.cardholder} · Exp ${billingState.summary.expiry}`;
+    }
+    if (summaryNext) {
+      summaryNext.textContent = `${formatDate(billingState.summary.nextInvoiceDate)} · ${formatCurrency(
+        billingState.summary.invoiceAmount
+      )}`;
+    }
+    if (summaryAddress) {
+      summaryAddress.textContent = billingState.summary.address;
+    }
+  }
+
+  function prefillEditForm() {
+    if (!editForm) return;
+    const method = editForm.querySelector('#editMethod');
+    const cardholder = editForm.querySelector('#editCardholder');
+    const cardNumber = editForm.querySelector('#editCard');
+    const expiry = editForm.querySelector('#editExpiry');
+    const nextPayment = editForm.querySelector('#editNextPayment');
+    const amount = editForm.querySelector('#editAmount');
+    const address = editForm.querySelector('#editAddress');
+    const autopay = editForm.querySelector('#editAutopay');
+
+    if (method) method.value = billingState.summary.methodName;
+    if (cardholder) cardholder.value = billingState.summary.cardholder;
+    if (cardNumber) cardNumber.value = billingState.summary.cardNumber;
+    if (expiry) expiry.value = billingState.summary.expiry;
+    if (nextPayment) nextPayment.value = billingState.summary.nextInvoiceDate;
+    if (amount) amount.value = billingState.summary.invoiceAmount;
+    if (address) address.value = billingState.summary.address;
+    if (autopay) autopay.value = billingState.autopay ? 'enabled' : 'paused';
+  }
+
+  function renderHistory(filterText = '') {
+    if (!historyBody) return;
+    const query = filterText.trim().toLowerCase();
+    const filtered = BILLING_HISTORY.filter(entry => {
+      const dateLabel = formatDate(entry.date).toLowerCase();
+      return (
+        entry.invoice.toLowerCase().includes(query) ||
+        dateLabel.includes(query) ||
+        formatCurrency(entry.amount).toLowerCase().includes(query) ||
+        STATUS_CONFIG[entry.status]?.label.toLowerCase().includes(query)
+      );
+    });
+
+    historyBody.innerHTML = '';
+
+    if (filtered.length === 0) {
+      const emptyRow = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 5;
+      cell.className = 'table-empty';
+      cell.textContent = 'No invoices match your search just yet.';
+      emptyRow.appendChild(cell);
+      historyBody.appendChild(emptyRow);
+      return;
+    }
+
+    filtered.forEach(entry => {
+      const row = document.createElement('tr');
+      const status = STATUS_CONFIG[entry.status] || STATUS_CONFIG.processing;
+      row.innerHTML = `
+        <td>${formatDate(entry.date)}</td>
+        <td>${entry.invoice}</td>
+        <td>${formatCurrency(entry.amount)}</td>
+        <td><span class="status-pill ${status.className}">${status.label}</span></td>
+        <td><button type="button" class="payment-history__receipt billing-history__download" data-receipt="${entry.invoice}">Download</button></td>
+      `;
+      historyBody.appendChild(row);
+    });
+  }
+
+  function updateAutopayUI(isEnabled) {
+    autopayPills.forEach(pill => {
+      pill.textContent = isEnabled ? 'Autopay Enabled' : 'Autopay Paused';
+      pill.classList.toggle('business-badge--success', isEnabled);
+      pill.classList.toggle('business-badge--warning', !isEnabled);
+      pill.classList.toggle('business-badge--muted', false);
+    });
+    if (autopayButton) {
+      autopayButton.textContent = isEnabled ? 'Pause autopay' : 'Resume autopay';
+    }
+  }
+
+  function showFeedback(message, variant = 'success') {
+    if (!feedback) return;
+    feedback.textContent = message;
+    feedback.hidden = false;
+    feedback.classList.remove('page-feedback--success', 'page-feedback--info', 'page-feedback--error');
+    feedback.classList.add(`page-feedback--${variant}`);
+    clearTimeout(feedbackTimeoutId);
+    feedbackTimeoutId = window.setTimeout(() => {
+      feedback.hidden = true;
+    }, 6000);
+  }
+});
+
+function formatCurrency(amount) {
+  const value = typeof amount === 'number' ? amount : parseFloat(amount || '0');
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(value);
+}
+
+function formatDate(dateString) {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return dateString;
+  }
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  });
+}
+
+function getLastFour(value) {
+  const digits = sanitizeNumber(value);
+  return digits ? digits.slice(-4) : '0000';
+}
+
+function sanitizeNumber(value) {
+  return value ? value.toString().replace(/\D+/g, '') : '';
+}
+
+function describeUsage(usage) {
+  switch (usage) {
+    case 'manual':
+      return 'manual one-time payments';
+    case 'split':
+      return 'split invoices with the primary method';
+    default:
+      return 'backup coverage';
+  }
+}

--- a/business-dashboard.html
+++ b/business-dashboard.html
@@ -24,7 +24,7 @@
         </div>
         <nav class="menu enterprise-menu">
           <a class="active" href="#">Overview</a>
-          <a href="#">Plans &amp; Billing</a>
+          <a href="business-plans-billing.html">Plans &amp; Billing</a>
           <a href="#">Support</a>
           <a href="#">Settings</a>
         </nav>

--- a/business-plans-billing.html
+++ b/business-plans-billing.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard - Plans &amp; Billing</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="dashboard.css" />
+  </head>
+  <body>
+    <div class="dashboard business-dashboard">
+      <aside class="sidebar sidebar--business" aria-label="Workspace navigation">
+        <div class="company-summary">
+          <div class="company-avatar" aria-hidden="true">LB</div>
+          <h1>LegacyBridge</h1>
+          <p class="company-plan">Enterprise Shield · 62 seats</p>
+          <p class="company-renewal">Renewal in 120 days</p>
+        </div>
+        <nav class="menu menu--business" aria-label="Primary">
+          <p class="menu-label">Workspace</p>
+          <a href="business-dashboard.html">Overview</a>
+          <a href="business-profile.html">Business Profile</a>
+          <a href="#">Team Access</a>
+          <a href="#">Verification</a>
+          <a href="business-plans-billing.html" class="active">Plans &amp; Billing</a>
+          <a href="#">Support</a>
+        </nav>
+        <div class="sidebar-bottom sidebar-bottom--business">
+          <div class="support-card">
+            <p>Need a hand with onboarding?</p>
+            <button class="business-button business-button--ghost" type="button">
+              Contact Support
+            </button>
+          </div>
+          <button class="logout logout--business" type="button">Sign Out</button>
+        </div>
+      </aside>
+
+      <main class="business-main business-main--billing">
+        <div class="breadcrumb">Dashboard • Plans &amp; Billing</div>
+        <header class="business-header">
+          <div>
+            <h2 class="business-eyebrow">Company Plans &amp; Billing</h2>
+            <h1>Plans &amp; Billing</h1>
+            <p class="business-subtitle">
+              Review active coverage, manage payment preferences, and download invoices for
+              compliance records in one place.
+            </p>
+            <div class="business-header__meta">
+              <span class="business-badge">Coverage renewed Apr 18, 2025</span>
+              <span class="business-badge business-badge--success" data-autopay-pill>
+                Autopay Enabled
+              </span>
+            </div>
+          </div>
+          <div class="business-header__actions">
+            <button
+              class="business-button business-button--primary"
+              type="button"
+              data-open-forms="edit"
+            >
+              Update payment method
+            </button>
+            <button class="business-button business-button--ghost" type="button">Download invoice CSV</button>
+          </div>
+        </header>
+
+        <div
+          id="billingFeedback"
+          class="page-feedback page-feedback--success"
+          role="status"
+          aria-live="polite"
+          hidden
+        ></div>
+
+        <section id="billingOverview" class="billing-overview">
+          <div class="billing-grid">
+            <article class="business-card billing-card billing-card--plan">
+              <div class="business-card__header">
+                <div>
+                  <h3>Plan Overview</h3>
+                  <p>Snapshot of your company coverage and renewal cadence.</p>
+                </div>
+                <span class="status-pill status-pill--success" data-plan-status>Active</span>
+              </div>
+              <dl class="info-grid">
+                <div class="info-item">
+                  <dt>Plan name</dt>
+                  <dd data-plan-name>Enterprise Shield</dd>
+                </div>
+                <div class="info-item">
+                  <dt>Employees covered</dt>
+                  <dd data-plan-employees>62 active · 4 pending invites</dd>
+                </div>
+                <div class="info-item">
+                  <dt>Annual coverage</dt>
+                  <dd data-plan-coverage>$250,000 across medical &amp; wellness</dd>
+                </div>
+                <div class="info-item">
+                  <dt>Next renewal</dt>
+                  <dd data-plan-renewal>Apr 18, 2026 · Auto-renew</dd>
+                </div>
+              </dl>
+              <div class="billing-plan__actions">
+                <button class="business-button business-button--ghost" type="button">View plan documents</button>
+                <button class="business-button business-button--ghost" type="button">Share coverage summary</button>
+              </div>
+            </article>
+
+            <article class="business-card billing-card billing-card--payment" id="billingSummaryCard">
+              <div class="business-card__header">
+                <div>
+                  <h3>Billing Details</h3>
+                  <p>Primary payment method, billing cadence, and autopay settings.</p>
+                </div>
+                <button class="business-button business-button--ghost" type="button" data-open-forms="edit">
+                  Manage
+                </button>
+              </div>
+              <div class="billing-summary">
+                <div class="billing-summary__method">
+                  <h4>Primary payment method</h4>
+                  <p class="billing-summary__value" data-summary-method>Corporate Visa •••• 4321</p>
+                  <p class="billing-summary__meta" data-summary-meta>LegacyBridge Benefits · Exp 11/27</p>
+                </div>
+                <div class="billing-summary__meta">
+                  <p><strong>Next invoice:</strong> <span data-summary-next>May 15, 2025 · $4,820.00</span></p>
+                  <p><strong>Billing address:</strong> <span data-summary-address>4100 Market Street, Suite 1200 · Denver, CO 80205</span></p>
+                  <div class="billing-autopay">
+                    <span class="business-badge business-badge--success" data-autopay-pill>Autopay Enabled</span>
+                    <button class="business-button business-button--ghost" type="button" data-toggle-autopay>
+                      Pause autopay
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="billing-summary__actions">
+                <button class="business-button business-button--primary" type="button" data-open-forms="edit">
+                  Update payment method
+                </button>
+                <button class="business-button business-button--ghost" type="button" data-open-forms="add">
+                  Add backup method
+                </button>
+              </div>
+            </article>
+
+            <article class="business-card billing-card billing-card--contacts">
+              <div class="business-card__header">
+                <div>
+                  <h3>Billing Contacts</h3>
+                  <p>People copied on invoices, reminders, and renewal notices.</p>
+                </div>
+                <button class="business-button business-button--ghost" type="button">Manage contacts</button>
+              </div>
+              <ul class="billing-contact-list" aria-label="Billing contacts">
+                <li class="billing-contact">
+                  <div>
+                    <h4>Ana Velásquez</h4>
+                    <p>Finance Lead · ana.velasquez@legacybridge.co</p>
+                  </div>
+                  <span class="business-badge">Primary</span>
+                </li>
+                <li class="billing-contact">
+                  <div>
+                    <h4>Jordan Patel</h4>
+                    <p>Controller · jordan.patel@legacybridge.co</p>
+                  </div>
+                  <span class="business-badge business-badge--muted">CC</span>
+                </li>
+                <li class="billing-contact">
+                  <div>
+                    <h4>Samira Rhodes</h4>
+                    <p>HR Operations · samira.rhodes@legacybridge.co</p>
+                  </div>
+                  <span class="business-badge business-badge--muted">CC</span>
+                </li>
+              </ul>
+              <p class="business-card__footnote">
+                Keep at least one billing contact updated to ensure renewal reminders are never missed.
+              </p>
+            </article>
+          </div>
+
+          <section class="business-card billing-history" aria-labelledby="billing-history-heading">
+            <div class="billing-history__header">
+              <div>
+                <h3 id="billing-history-heading">Billing History</h3>
+                <p>Track recent invoices, payment status, and download receipts.</p>
+              </div>
+              <label class="billing-history__search" for="billingHistorySearch">
+                <span class="sr-only">Search invoices</span>
+                <input type="search" id="billingHistorySearch" placeholder="Search invoices" />
+              </label>
+            </div>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Date</th>
+                    <th scope="col">Invoice</th>
+                    <th scope="col">Amount</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Receipt</th>
+                  </tr>
+                </thead>
+                <tbody id="billingHistoryBody"></tbody>
+              </table>
+            </div>
+          </section>
+        </section>
+
+        <section class="billing-forms" id="billingForms" hidden aria-label="Manage payment methods">
+          <div class="billing-forms__intro">
+            <h2>Manage Payment Methods</h2>
+            <p>
+              Update the active card on file or add a backup method for manual payments. Changes apply to
+              all future invoices.
+            </p>
+          </div>
+          <div class="billing-forms__grid">
+            <form class="billing-form business-form business-card" id="editBillingForm" data-form="edit">
+              <div class="business-card__header">
+                <div>
+                  <h3>Edit primary payment method</h3>
+                  <p>Adjust billing details that appear on monthly invoices.</p>
+                </div>
+              </div>
+              <div class="form-grid">
+                <label class="form-field">
+                  <span>Payment method name</span>
+                  <input type="text" name="method" id="editMethod" required />
+                </label>
+                <label class="form-field">
+                  <span>Cardholder or account name</span>
+                  <input type="text" name="cardholder" id="editCardholder" required />
+                </label>
+                <label class="form-field">
+                  <span>Card number</span>
+                  <input type="text" name="cardNumber" id="editCard" inputmode="numeric" autocomplete="cc-number" required />
+                </label>
+                <label class="form-field">
+                  <span>Expiration (MM/YY)</span>
+                  <input type="text" name="expiry" id="editExpiry" placeholder="MM/YY" autocomplete="cc-exp" required />
+                </label>
+                <label class="form-field">
+                  <span>Autopay status</span>
+                  <select name="autopay" id="editAutopay">
+                    <option value="enabled">Enabled</option>
+                    <option value="paused">Paused</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Next invoice date</span>
+                  <input type="date" name="nextPayment" id="editNextPayment" required />
+                </label>
+                <label class="form-field">
+                  <span>Invoice amount</span>
+                  <input type="number" name="invoiceAmount" id="editAmount" min="0" step="0.01" required />
+                </label>
+                <label class="form-field">
+                  <span>Billing address</span>
+                  <input type="text" name="billingAddress" id="editAddress" required />
+                </label>
+              </div>
+              <div class="billing-form__actions">
+                <button class="business-button business-button--ghost" type="button" data-close-forms>Cancel</button>
+                <button class="business-button business-button--primary" type="submit">Save changes</button>
+              </div>
+            </form>
+
+            <form class="billing-form business-form business-card" id="addBillingForm" data-form="add">
+              <div class="business-card__header">
+                <div>
+                  <h3>Add backup payment method</h3>
+                  <p>Store an additional method for manual or emergency payments.</p>
+                </div>
+              </div>
+              <div class="form-grid">
+                <label class="form-field">
+                  <span>Payment method name</span>
+                  <input type="text" name="method" id="addMethod" placeholder="Corporate Amex, ACH" required />
+                </label>
+                <label class="form-field">
+                  <span>Account owner</span>
+                  <input type="text" name="cardholder" id="addCardholder" required />
+                </label>
+                <label class="form-field">
+                  <span>Account number</span>
+                  <input type="text" name="cardNumber" id="addAccountNumber" inputmode="numeric" required />
+                </label>
+                <label class="form-field">
+                  <span>Expiration or routing</span>
+                  <input type="text" name="expiry" id="addExpiry" placeholder="MM/YY or Routing" />
+                </label>
+                <label class="form-field">
+                  <span>Preferred usage</span>
+                  <select name="preferredUsage" id="addUsage">
+                    <option value="backup">Backup - only if primary fails</option>
+                    <option value="manual">Manual one-time payments</option>
+                    <option value="split">Split invoices with primary</option>
+                  </select>
+                </label>
+                <label class="form-field">
+                  <span>Billing contact email</span>
+                  <input type="email" name="billingEmail" id="addEmail" placeholder="billing@legacybridge.co" />
+                </label>
+                <label class="form-field form-field--full">
+                  <span>Notes</span>
+                  <textarea name="notes" id="addNotes" rows="4" placeholder="Add internal instructions or handoff details"></textarea>
+                </label>
+              </div>
+              <div class="billing-form__actions">
+                <button class="business-button business-button--ghost" type="button" data-close-forms>Cancel</button>
+                <button class="business-button business-button--primary" type="submit">Add payment method</button>
+              </div>
+            </form>
+          </div>
+        </section>
+      </main>
+    </div>
+    <script src="business-billing.js"></script>
+  </body>
+</html>

--- a/business-profile.html
+++ b/business-profile.html
@@ -24,7 +24,7 @@
         <a href="#">Business Profile</a>
         <a href="#">Team Access</a>
         <a href="#">Verification</a>
-        <a href="#">Billing</a>
+        <a href="business-plans-billing.html">Billing</a>
         <a href="#">Support</a>
       </nav>
       <div class="sidebar-bottom sidebar-bottom--business">

--- a/dashboard.css
+++ b/dashboard.css
@@ -2314,6 +2314,16 @@ body.modal-open {
   color: var(--color-forest-900);
 }
 
+.business-badge--warning {
+  background: rgba(228, 158, 64, 0.22);
+  color: #8a5707;
+}
+
+.business-badge--muted {
+  background: rgba(22, 60, 48, 0.1);
+  color: rgba(22, 60, 48, 0.85);
+}
+
 .business-header__actions {
   display: flex;
   gap: 0.75rem;
@@ -2648,6 +2658,179 @@ body.modal-open {
   justify-content: flex-end;
 }
 
+.business-main--billing {
+  gap: 2.75rem;
+}
+
+.billing-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.billing-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.billing-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.billing-plan__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.billing-summary {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.billing-summary__method h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted);
+}
+
+.billing-summary__value {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.billing-summary__meta p {
+  margin: 0 0 0.4rem;
+  color: var(--color-muted);
+}
+
+.billing-summary__meta p:last-child {
+  margin-bottom: 0;
+}
+
+.billing-autopay {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.billing-summary__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: auto;
+}
+
+.billing-contact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.billing-contact {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(22, 60, 48, 0.12);
+}
+
+.billing-contact:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.billing-contact h4 {
+  margin: 0 0 0.25rem;
+}
+
+.billing-contact p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.92rem;
+}
+
+.billing-history {
+  gap: 1.5rem;
+}
+
+.billing-history__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.billing-history__search input {
+  min-width: 220px;
+  border-radius: 12px;
+  border: 1px solid rgba(22, 60, 48, 0.18);
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+}
+
+.billing-forms {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.billing-forms__intro {
+  max-width: 620px;
+}
+
+.billing-forms__intro h2 {
+  margin: 0 0 0.35rem;
+}
+
+.billing-forms__intro p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.billing-forms__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.billing-form {
+  gap: 1.5rem;
+  border: 1px solid rgba(22, 60, 48, 0.12);
+}
+
+.billing-form.is-active {
+  border-color: rgba(22, 60, 48, 0.28);
+  box-shadow: 0 26px 45px rgba(17, 40, 32, 0.16);
+}
+
+.billing-form__actions {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.business-form .form-field.form-field--full {
+  grid-column: 1 / -1;
+}
+
 @media (max-width: 1100px) {
   .document-editor__row {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2670,6 +2853,14 @@ body.modal-open {
   .document-editor__row {
     grid-template-columns: minmax(0, 1fr);
   }
+
+  .billing-summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .billing-summary__actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 640px) {
@@ -2679,5 +2870,17 @@ body.modal-open {
 
   .business-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .billing-history__search input {
+    width: 100%;
+  }
+
+  .billing-plan__actions {
+    width: 100%;
+  }
+
+  .billing-plan__actions .business-button {
+    flex: 1;
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated business Plans & Billing page with coverage overview, contacts, and billing history
- implement interactive scripts to toggle autopay, manage payment method forms, and filter invoices
- extend shared dashboard styling for billing layouts and wire existing navigation links to the new page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d3efa2c770832797117f0f681ff1f2