### PR TITLE
Add business support and settings views

### DIFF
--- a/business-dashboard.html
+++ b/business-dashboard.html
@@ -25,8 +25,8 @@
         <nav class="menu enterprise-menu">
           <a class="active" href="#">Overview</a>
           <a href="business-plans-billing.html">Plans &amp; Billing</a>
-          <a href="#">Support</a>
-          <a href="#">Settings</a>
+          <a href="business-support.html">Support</a>
+          <a href="business-settings.html">Settings</a>
         </nav>
         <div class="sidebar-bottom enterprise-sidebar-bottom">
           <button class="logout">Log Out</button>

--- a/business-plans-billing.html
+++ b/business-plans-billing.html
@@ -28,7 +28,7 @@
           <a href="#">Team Access</a>
           <a href="#">Verification</a>
           <a href="business-plans-billing.html" class="active">Plans &amp; Billing</a>
-          <a href="#">Support</a>
+          <a href="business-support.html">Support</a>
         </nav>
         <div class="sidebar-bottom sidebar-bottom--business">
           <div class="support-card">

--- a/business-profile.html
+++ b/business-profile.html
@@ -25,7 +25,7 @@
         <a href="#">Team Access</a>
         <a href="#">Verification</a>
         <a href="business-plans-billing.html">Billing</a>
-        <a href="#">Support</a>
+        <a href="business-support.html">Support</a>
       </nav>
       <div class="sidebar-bottom sidebar-bottom--business">
         <div class="support-card">

--- a/business-settings.html
+++ b/business-settings.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard - Settings</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="dashboard.css" />
+  </head>
+  <body>
+    <div class="dashboard dashboard--enterprise" data-settings-prefix="legacybridge-settings-">
+      <aside class="sidebar sidebar--enterprise" aria-label="Employer portal navigation">
+        <div class="enterprise-brand">
+          <div class="enterprise-brand__icon" aria-hidden="true">LB</div>
+          <div class="enterprise-brand__text">
+            <span class="enterprise-brand__label">LegacyBridge</span>
+            <span class="enterprise-brand__sub">Employer Portal</span>
+          </div>
+        </div>
+        <nav class="menu enterprise-menu" aria-label="Primary">
+          <a href="business-dashboard.html">Overview</a>
+          <a href="business-plans-billing.html">Plans &amp; Billing</a>
+          <a href="business-support.html">Support</a>
+          <a href="business-settings.html" class="active" aria-current="page">Settings</a>
+        </nav>
+        <div class="sidebar-bottom enterprise-sidebar-bottom">
+          <button class="logout" type="button">Log Out</button>
+          <div class="lang" aria-label="Language selection">
+            <button class="active" type="button">English</button>
+            <button type="button">Español</button>
+          </div>
+        </div>
+      </aside>
+
+      <main class="main-content main-content--enterprise settings-main settings-main--enterprise">
+        <header class="content-header settings-header">
+          <div>
+            <span class="eyebrow">Employer Controls</span>
+            <h1>Settings</h1>
+          </div>
+          <p class="member-since">Workspace last reviewed April 12, 2025</p>
+        </header>
+
+        <section class="settings-hero enterprise-settings-hero" aria-label="Workspace overview">
+          <div class="hero-copy">
+            <h2>Tailor LegacyBridge for your organization</h2>
+            <p>
+              Manage how administrators receive alerts, keep your login experience secure, and control the data we retain for your workforce.
+            </p>
+          </div>
+          <dl class="hero-meta">
+            <div>
+              <dt>Plan</dt>
+              <dd>Enterprise Shield</dd>
+            </div>
+            <div>
+              <dt>Employees covered</dt>
+              <dd>62 active · 4 pending</dd>
+            </div>
+            <div>
+              <dt>Assigned specialist</dt>
+              <dd>Jordan Patel</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd class="status-pill success">In good standing</dd>
+            </div>
+          </dl>
+        </section>
+
+        <div class="settings-layout enterprise-settings-layout">
+          <aside class="settings-nav" aria-label="Settings sections">
+            <div class="nav-heading">
+              <span class="eyebrow">LegacyBridge Settings</span>
+              <h2>Manage your workspace</h2>
+              <p>Choose a category to update notifications, account security, or retained data.</p>
+            </div>
+            <nav class="nav-links" role="tablist">
+              <button
+                class="nav-link active"
+                id="enterpriseTabNotifications"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                aria-controls="enterpriseNotificationsPanel"
+                data-target="enterpriseNotificationsPanel"
+              >
+                Notifications
+              </button>
+              <button
+                class="nav-link"
+                id="enterpriseTabPrivacy"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="enterprisePrivacyPanel"
+                data-target="enterprisePrivacyPanel"
+              >
+                Privacy &amp; Security
+              </button>
+              <button
+                class="nav-link"
+                id="enterpriseTabData"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="enterpriseDataPanel"
+                data-target="enterpriseDataPanel"
+              >
+                Data &amp; Privacy
+              </button>
+            </nav>
+            <div class="nav-support">
+              <h3>Need assistance?</h3>
+              <p>Visit the help center to chat with a specialist or review onboarding checklists.</p>
+              <a class="support-link" href="business-support.html">Open support</a>
+            </div>
+          </aside>
+
+          <div class="settings-content" role="presentation">
+            <section
+              id="enterpriseNotificationsPanel"
+              class="settings-panel active"
+              role="tabpanel"
+              aria-labelledby="enterpriseTabNotifications"
+              tabindex="0"
+            >
+              <header class="panel-header">
+                <h2>Notifications</h2>
+                <p>Decide which LegacyBridge alerts reach your administrator team.</p>
+              </header>
+              <div class="preference-list">
+                <article class="preference-item">
+                  <div class="preference-copy">
+                    <h3>Plan announcements</h3>
+                    <p>New coverage options, enhancements, and changes to employee eligibility.</p>
+                  </div>
+                  <label class="toggle" for="notifyPlan">
+                    <input type="checkbox" id="notifyPlan" data-storage="notifyPlan" checked />
+                    <span class="toggle-control" aria-hidden="true"></span>
+                  </label>
+                </article>
+                <article class="preference-item">
+                  <div class="preference-copy">
+                    <h3>Renewal reminders</h3>
+                    <p>Heads-up emails leading into open enrollment or rate adjustments.</p>
+                  </div>
+                  <label class="toggle" for="notifyRenewal">
+                    <input type="checkbox" id="notifyRenewal" data-storage="notifyRenewal" checked />
+                    <span class="toggle-control" aria-hidden="true"></span>
+                  </label>
+                </article>
+                <article class="preference-item">
+                  <div class="preference-copy">
+                    <h3>Onboarding updates</h3>
+                    <p>Alerts when employees accept invitations or require additional documents.</p>
+                  </div>
+                  <label class="toggle" for="notifyOnboarding">
+                    <input type="checkbox" id="notifyOnboarding" data-storage="notifyOnboarding" />
+                    <span class="toggle-control" aria-hidden="true"></span>
+                  </label>
+                </article>
+                <article class="preference-item">
+                  <div class="preference-copy">
+                    <h3>Billing notifications</h3>
+                    <p>Invoices posted, payment confirmations, and autopay status changes.</p>
+                  </div>
+                  <label class="toggle" for="notifyBilling">
+                    <input type="checkbox" id="notifyBilling" data-storage="notifyBilling" checked />
+                    <span class="toggle-control" aria-hidden="true"></span>
+                  </label>
+                </article>
+              </div>
+              <div class="panel-actions">
+                <button class="button outline-button" type="button" data-action="resetNotifications">Reset</button>
+                <button class="button solid-button" type="button" id="saveNotifications">Save changes</button>
+              </div>
+            </section>
+
+            <section
+              id="enterprisePrivacyPanel"
+              class="settings-panel"
+              role="tabpanel"
+              aria-labelledby="enterpriseTabPrivacy"
+              tabindex="0"
+            >
+              <header class="panel-header">
+                <h2>Privacy &amp; Security</h2>
+                <p>Protect administrator accounts and integrate with your identity provider.</p>
+              </header>
+              <div class="security-grid">
+                <article class="security-item">
+                  <div>
+                    <h3>Single sign-on</h3>
+                    <p>Connect Okta, Azure AD, or Google Workspace for seamless access.</p>
+                  </div>
+                  <div class="item-actions">
+                    <span class="status-pill neutral">Not connected</span>
+                    <button class="button ghost-button" type="button">Configure SSO</button>
+                  </div>
+                </article>
+                <article class="security-item">
+                  <div>
+                    <h3>Multi-factor authentication</h3>
+                    <p>Require a secondary code whenever admins sign in on a new device.</p>
+                  </div>
+                  <div class="item-actions">
+                    <span class="status-pill" data-twofa-status>Disabled</span>
+                    <button class="button solid-button" type="button" data-action="toggleTwoFA">Enable</button>
+                  </div>
+                </article>
+                <article class="security-item">
+                  <div>
+                    <h3>Login alerts</h3>
+                    <p>Be notified when access is detected from unusual locations or browsers.</p>
+                  </div>
+                  <label class="toggle" for="enterpriseLoginAlerts">
+                    <input
+                      type="checkbox"
+                      id="enterpriseLoginAlerts"
+                      data-storage="enterpriseLoginAlerts"
+                      data-auto-save="true"
+                      checked
+                    />
+                    <span class="toggle-control" aria-hidden="true"></span>
+                  </label>
+                </article>
+              </div>
+            </section>
+
+            <section
+              id="enterpriseDataPanel"
+              class="settings-panel"
+              role="tabpanel"
+              aria-labelledby="enterpriseTabData"
+              tabindex="0"
+            >
+              <header class="panel-header">
+                <h2>Data &amp; Privacy</h2>
+                <p>Request exports or control retention for employee information.</p>
+              </header>
+              <div class="data-grid">
+                <article class="data-item">
+                  <div>
+                    <h3>Download coverage roster</h3>
+                    <p>Receive a secure CSV of employees, dependents, and current plan selections.</p>
+                  </div>
+                  <button class="button solid-button" type="button" data-action="downloadData">Send download</button>
+                </article>
+                <article class="data-item">
+                  <div>
+                    <h3>Audit invoice archive</h3>
+                    <p>Generate a year-to-date folder of invoices and payment confirmations.</p>
+                  </div>
+                  <button class="button ghost-button" type="button" data-action="exportStatements">Export</button>
+                </article>
+                <article class="data-item danger">
+                  <div>
+                    <h3>Request data purge</h3>
+                    <p>This begins a 30-day review before we delete all saved employee records.</p>
+                  </div>
+                  <button class="button danger-button" type="button" data-action="deleteAccount">Request removal</button>
+                </article>
+              </div>
+            </section>
+          </div>
+        </div>
+      </main>
+    </div>
+    <script src="settings.js"></script>
+  </body>
+</html>

--- a/business-support.html
+++ b/business-support.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard - Support</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="dashboard.css" />
+  </head>
+  <body>
+    <div class="dashboard dashboard--enterprise">
+      <aside class="sidebar sidebar--enterprise" aria-label="Employer portal navigation">
+        <div class="enterprise-brand">
+          <div class="enterprise-brand__icon" aria-hidden="true">LB</div>
+          <div class="enterprise-brand__text">
+            <span class="enterprise-brand__label">LegacyBridge</span>
+            <span class="enterprise-brand__sub">Employer Portal</span>
+          </div>
+        </div>
+        <nav class="menu enterprise-menu" aria-label="Primary">
+          <a href="business-dashboard.html">Overview</a>
+          <a href="business-plans-billing.html">Plans &amp; Billing</a>
+          <a href="business-support.html" class="active" aria-current="page">Support</a>
+          <a href="business-settings.html">Settings</a>
+        </nav>
+        <div class="sidebar-bottom enterprise-sidebar-bottom">
+          <button class="logout" type="button">Log Out</button>
+          <div class="lang" aria-label="Language selection">
+            <button class="active" type="button">English</button>
+            <button type="button">Español</button>
+          </div>
+        </div>
+      </aside>
+
+      <main class="main-content main-content--enterprise support-main">
+        <header class="page-heading page-heading--enterprise support-heading">
+          <p class="breadcrumb">Dashboard • Support</p>
+          <h1>Support</h1>
+          <p class="page-heading__subtitle">
+            Partner with our care team to onboard employees, answer plan questions, and resolve billing needs without the wait.
+          </p>
+        </header>
+
+        <section class="support-hero" aria-label="Help center overview">
+          <div class="support-hero__body">
+            <span class="eyebrow">Help Center</span>
+            <h2>Dedicated support for your workforce</h2>
+            <p>
+              Access guided onboarding, plan documentation, and real specialists who understand employer benefits. We keep your organization informed so every employee feels taken care of.
+            </p>
+            <div class="support-hero__actions">
+              <button class="support-button support-button--primary" type="button">Open help center</button>
+              <button class="support-button" type="button">Schedule onboarding</button>
+            </div>
+          </div>
+          <dl class="support-hero__meta">
+            <div>
+              <dt>Care hours</dt>
+              <dd>Mon–Fri · 7am–7pm CT</dd>
+            </div>
+            <div>
+              <dt>Priority phone</dt>
+              <dd>+1 (888) 555-0128</dd>
+            </div>
+            <div>
+              <dt>Average response</dt>
+              <dd>Under 10 minutes</dd>
+            </div>
+            <div>
+              <dt>Dedicated specialist</dt>
+              <dd>Jordan Patel</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="support-contact" aria-label="Contact options">
+          <h2>Contact our care specialists</h2>
+          <div class="support-contact__grid">
+            <article class="support-card">
+              <div class="support-card__icon" aria-hidden="true">💬</div>
+              <h3>Chat with us</h3>
+              <p>Start a secure chat to get answers about eligibility, invoices, or onboarding in real time.</p>
+              <button class="support-link" type="button">Start live chat</button>
+            </article>
+            <article class="support-card">
+              <div class="support-card__icon" aria-hidden="true">📞</div>
+              <h3>Call our hotline</h3>
+              <p>Speak directly with a benefits specialist for escalations or time-sensitive requests.</p>
+              <div class="support-card__meta">
+                <span>+1 (888) 555-0128</span>
+                <span>Mon–Fri · 7am–7pm CT</span>
+              </div>
+            </article>
+            <article class="support-card">
+              <div class="support-card__icon" aria-hidden="true">📧</div>
+              <h3>Email the team</h3>
+              <p>Send detailed documentation or upload rosters and we will respond with next steps.</p>
+              <button class="support-link" type="button">support@legacybridge.com</button>
+            </article>
+          </div>
+        </section>
+
+        <section class="support-resources" aria-label="Resources">
+          <div class="support-resources__header">
+            <h2>Popular employer resources</h2>
+            <a class="support-link" href="#">Browse resource library</a>
+          </div>
+          <div class="support-resources__grid">
+            <article class="resource-card">
+              <h3>Onboarding toolkit</h3>
+              <p>Templates, welcome emails, and launch materials to introduce LegacyBridge to new hires.</p>
+              <ul>
+                <li>Checklist for HR teams</li>
+                <li>Employee FAQ PDF</li>
+                <li>Benefits kickoff deck</li>
+              </ul>
+            </article>
+            <article class="resource-card">
+              <h3>Claims &amp; coverage guides</h3>
+              <p>Step-by-step instructions to help employees submit claims and understand their coverage.</p>
+              <ul>
+                <li>Claims submission walkthrough</li>
+                <li>Coverage tiers overview</li>
+                <li>International travel add-ons</li>
+              </ul>
+            </article>
+            <article class="resource-card">
+              <h3>Billing &amp; compliance</h3>
+              <p>Stay audit ready with invoice reports, tax documentation, and compliance checklists.</p>
+              <ul>
+                <li>Monthly invoice reconciliation</li>
+                <li>1095-C distribution guide</li>
+                <li>State-by-state requirements</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="support-faq" aria-label="Support quick answers">
+          <h2>Quick answers</h2>
+          <div class="support-faq__grid">
+            <article class="faq-card">
+              <h3>How do we add or remove employees?</h3>
+              <p>Upload a roster in CSV or sync your HRIS to automatically provision coverage for new team members.</p>
+              <a class="support-link" href="#">View employee onboarding guide</a>
+            </article>
+            <article class="faq-card">
+              <h3>Where can I review pending claims?</h3>
+              <p>Navigate to Plans &amp; Billing &gt; Claims to monitor status updates and export detailed reports.</p>
+              <a class="support-link" href="#">Open claims dashboard</a>
+            </article>
+            <article class="faq-card">
+              <h3>Need escalated assistance?</h3>
+              <p>Message Jordan Patel, your assigned specialist, for complex approvals or compliance questions.</p>
+              <a class="support-link" href="#">Message my specialist</a>
+            </article>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/dashboard.css
+++ b/dashboard.css
@@ -423,6 +423,247 @@ button {
   font-size: 0.9rem;
 }
 
+.support-main {
+  gap: clamp(2rem, 3.5vw, 3.25rem);
+}
+
+.support-heading .page-heading__subtitle {
+  max-width: 680px;
+}
+
+.support-hero {
+  background: linear-gradient(120deg, #f1f7f5 0%, #e3efe9 55%, #d2e8dd 100%);
+  border-radius: var(--radius-large);
+  padding: clamp(1.8rem, 3vw, 2.6rem);
+  display: grid;
+  gap: clamp(1.75rem, 2.5vw, 2.4rem);
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+  align-items: start;
+  box-shadow: 0 28px 46px rgba(17, 40, 32, 0.14);
+}
+
+.support-hero__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.support-hero__body h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+}
+
+.support-hero__body p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+}
+
+.support-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.support-button {
+  border-radius: 999px;
+  border: 1px solid rgba(20, 61, 49, 0.28);
+  padding: 0.7rem 1.5rem;
+  font-weight: 600;
+  background: #fff;
+  color: var(--color-forest-900);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.support-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 28px rgba(17, 40, 32, 0.16);
+}
+
+.support-button--primary {
+  background: var(--color-forest-900);
+  color: #fff;
+  border-color: transparent;
+}
+
+.support-hero__meta {
+  margin: 0;
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.support-hero__meta div {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 18px 30px rgba(17, 40, 32, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.support-hero__meta dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.support-hero__meta dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.support-contact,
+.support-resources,
+.support-faq {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.support-contact h2,
+.support-resources h2,
+.support-faq h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.5vw, 2.2rem);
+}
+
+.support-contact__grid,
+.support-resources__grid,
+.support-faq__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.support-card,
+.resource-card,
+.faq-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 24px 40px rgba(17, 40, 32, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.resource-card {
+  padding: 1.65rem;
+  box-shadow: 0 24px 40px rgba(17, 40, 32, 0.08);
+}
+
+.support-card__icon {
+  font-size: 1.6rem;
+}
+
+.support-card h3,
+.resource-card h3,
+.faq-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.support-card p,
+.resource-card p,
+.faq-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.support-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.support-resources__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.resource-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--color-forest-900);
+  font-weight: 500;
+}
+
+.support-link {
+  background: none;
+  border: none;
+  color: var(--color-forest-900);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.support-link::after {
+  content: '→';
+  font-size: 0.9em;
+  transition: transform 0.2s ease;
+}
+
+.support-link:focus-visible {
+  outline: 2px solid rgba(20, 61, 49, 0.35);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.support-link:hover::after {
+  transform: translateX(3px);
+}
+
+.settings-main--enterprise .settings-hero {
+  background: linear-gradient(120deg, #eef5f1 0%, #e2ede7 50%, #d3e7dc 100%);
+  box-shadow: 0 28px 46px rgba(17, 40, 32, 0.14);
+}
+
+.settings-main--enterprise .settings-nav {
+  box-shadow: 0 24px 40px rgba(17, 40, 32, 0.1);
+}
+
+.settings-main--enterprise .settings-panel {
+  box-shadow: 0 24px 40px rgba(17, 40, 32, 0.08);
+}
+
+@media (max-width: 1024px) {
+  .support-hero {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .support-hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .support-resources__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
 .page-heading__subtitle {
   margin: 0;
   color: var(--color-muted);

--- a/settings.html
+++ b/settings.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="dashboard.css">
 </head>
 <body>
-  <div class="dashboard settings-dashboard">
+  <div class="dashboard settings-dashboard" data-settings-prefix="ivy-settings-">
     <aside class="sidebar">
       <div class="profile">
         <img src="images/flying-kite.jpg" alt="Portrait of Maria Thompson">

--- a/settings.js
+++ b/settings.js
@@ -1,10 +1,9 @@
-const STORAGE_PREFIX = 'ivy-settings-';
-
-function buildStorageKey(input) {
-  return `${STORAGE_PREFIX}${input.dataset.storage}`;
-}
-
 document.addEventListener('DOMContentLoaded', () => {
+  const settingsRoot = document.querySelector('[data-settings-prefix]');
+  const storagePrefix = settingsRoot?.dataset.settingsPrefix ?? 'ivy-settings-';
+
+  const buildStorageKey = input => `${storagePrefix}${input.dataset.storage}`;
+
   const panels = document.querySelectorAll('.settings-panel');
   const navButtons = document.querySelectorAll('.settings-nav .nav-link');
   const toggleInputs = document.querySelectorAll('input[data-storage]');
@@ -84,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const twoFAButton = document.querySelector('[data-action="toggleTwoFA"]');
   const twoFAStatus = document.querySelector('[data-twofa-status]');
-  const twoFAKey = `${STORAGE_PREFIX}twoFA`;
+  const twoFAKey = `${storagePrefix}twoFA`;
 
   function updateTwoFAControls() {
     const enabled = localStorage.getItem(twoFAKey) === 'true';


### PR DESCRIPTION
## Summary
- add a dedicated LegacyBridge support page with hero, contact, resource, and FAQ sections
- create an enterprise-flavored settings experience with notifications, security, and data panels powered by scoped local storage keys
- update shared navigation and styling so existing business pages link into the new support and settings flows

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d3f624d6a48327b43299e735175684