### PR TITLE
Redesign individual dashboard layout

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -2101,21 +2101,33 @@ body.modal-open {
 
 /* Profile details layout */
 .profile-details {
-  background: var(--color-background);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  background: #f9f3e7;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  border-radius: 32px;
+  box-shadow: inset 0 0 0 1px rgba(22, 60, 48, 0.05);
+}
+
+.profile-panel {
+  background: #fff;
+  border-radius: 28px;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  box-shadow: 0 24px 50px rgba(17, 40, 32, 0.12);
+  display: flex;
+  flex-direction: column;
   gap: 1.75rem;
-  width: 100%;
-  max-width: 1100px;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .profile-details .content-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
+  align-items: flex-end;
   gap: 1rem;
-  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(22, 60, 48, 0.08);
 }
 
 .profile-details .eyebrow {
@@ -2134,266 +2146,97 @@ body.modal-open {
   color: rgba(22, 60, 48, 0.6);
 }
 
-.profile-details .info-card {
-  background: #fff;
-  border-radius: var(--radius-large);
-  padding: clamp(1.75rem, 2vw, 2.25rem);
-  box-shadow: var(--shadow-card);
+.panel-header {
   display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  align-items: center;
+  gap: 1.75rem;
 }
 
-.profile-details .card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: clamp(1rem, 2vw, 1.5rem);
-}
-
-.profile-details .card-header h2 {
-  margin: 0;
-  font-size: clamp(1.2rem, 2.4vw, 1.6rem);
-}
-
-.profile-details .card-header p {
-  margin: 0.35rem 0 0;
-  color: var(--color-muted);
-  max-width: 540px;
-}
-
-.profile-details .card-header > div:first-child {
-  flex: 1;
-}
-
-.profile-details .profile-glyph {
-  width: 108px;
+.panel-glyph {
+  width: clamp(110px, 18vw, 140px);
   aspect-ratio: 1 / 1;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f4e2bc;
-  border-radius: 50%;
-  box-shadow: 0 18px 30px rgba(17, 40, 32, 0.12);
+  background: #fbf5e7;
+  box-shadow: 0 18px 36px rgba(17, 40, 32, 0.12);
+  flex-shrink: 0;
 }
 
-.profile-details .profile-glyph svg {
+.panel-glyph svg {
   width: 80%;
-  height: auto;
+  height: 80%;
 }
 
-.profile-details .details-form {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.25rem, 2vw, 1.75rem);
+.panel-copy h2 {
+  font-size: clamp(1.5rem, 2.2vw, 1.9rem);
+  margin: 0 0 0.35rem;
 }
 
-.profile-details .form-grid {
-  display: grid;
-  gap: 1rem 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+.panel-copy p {
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 520px;
 }
 
-.profile-details .form-grid.two-column {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.profile-details .form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.profile-details .form-field span {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--color-forest-900);
-}
-
-.profile-details .details-form input,
-.profile-details .details-form select {
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(22, 60, 48, 0.18);
-  background: #f6f8f7;
-  font: inherit;
-  color: inherit;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-}
-
-.profile-details .details-form input:focus,
-.profile-details .details-form select:focus {
-  outline: none;
-  border-color: rgba(22, 60, 48, 0.55);
-  box-shadow: 0 0 0 4px rgba(22, 60, 48, 0.12);
-  background: #fff;
-}
-
-.profile-details .details-form select {
-  appearance: none;
-  background-image: url('data:image/svg+xml,%3Csvg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 6l4 4 4-4" stroke="%23163c30" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E');
-  background-repeat: no-repeat;
-  background-position: right 1rem center;
-  background-size: 16px;
-  padding-right: 2.75rem;
-}
-
-.profile-details .form-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.85rem;
-}
-
-.profile-details .button {
-  border-radius: 999px;
-  padding: 0.65rem 1.4rem;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
-}
-
-.profile-details .button:focus-visible {
-  outline: 3px solid rgba(31, 87, 72, 0.4);
-  outline-offset: 2px;
-}
-
-.profile-details .solid-button {
-  background: var(--color-forest-900);
-  color: #fff;
-  box-shadow: 0 16px 30px rgba(17, 40, 32, 0.22);
-}
-
-.profile-details .solid-button:hover {
-  transform: translateY(-1px);
-}
-
-.profile-details .outline-button {
-  background: transparent;
-  color: var(--color-forest-900);
-  border: 2px solid rgba(22, 60, 48, 0.35);
-}
-
-.profile-details .outline-button:hover {
-  background: rgba(22, 60, 48, 0.08);
-}
-
-.profile-details .ghost-button {
-  background: rgba(22, 60, 48, 0.08);
-  color: var(--color-forest-900);
-}
-
-.profile-details .ghost-button:hover {
-  background: rgba(22, 60, 48, 0.16);
-}
-
-.profile-details .documents-form {
+.panel-form {
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
 }
 
-.profile-details .document-item {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid rgba(22, 60, 48, 0.08);
-}
-
-.profile-details .document-item:last-of-type {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.profile-details .document-info h3 {
+.form-group {
+  border: none;
+  padding: 0;
   margin: 0;
-  font-size: clamp(1.1rem, 2vw, 1.3rem);
-}
-
-.profile-details .document-info p {
-  margin: 0.35rem 0 0;
-  color: var(--color-muted);
-}
-
-.profile-details .document-fields {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.profile-details .document-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem 1rem;
-}
-
-.profile-details .status-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 1rem;
-  border-radius: 999px;
+.form-group legend {
   font-weight: 600;
-  font-size: 0.85rem;
+  color: var(--color-forest-900);
+  font-size: 0.95rem;
 }
 
-.profile-details .status-success {
-  background: #e4f3e8;
-  color: #1a7f52;
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem 1.25rem;
 }
 
-.profile-details .status-warning {
-  background: #fff2d8;
-  color: #8a5b00;
+.field-pair {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem 1.25rem;
 }
 
-.profile-details .status-pending {
-  background: #fde1e1;
-  color: #b71c1c;
-}
-
-.profile-details .file-upload {
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-}
-
-.profile-details .file-name {
-  font-size: 0.9rem;
-  color: var(--color-muted);
-  word-break: break-word;
-}
-
-.profile-details .language-body {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1.25rem;
-}
-
-.profile-details .language-body p {
-  margin: 0 0 0.6rem;
-  color: var(--color-muted);
-}
-
-.profile-details .language-body > div {
+.form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
-.profile-details .language-select {
-  width: min(220px, 100%);
-  padding: 0.65rem 1rem;
+.form-field span {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-forest-900);
+}
+
+.form-field input,
+.form-field select {
+  padding: 0.85rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(22, 60, 48, 0.2);
-  background: #fff;
+  border: 1px solid #e1d7c0;
+  background: #fbf5e7;
   font: inherit;
+  color: var(--color-forest-900);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.form-field select {
   appearance: none;
   background-image: url('data:image/svg+xml,%3Csvg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 6l4 4 4-4" stroke="%23163c30" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E');
   background-repeat: no-repeat;
@@ -2401,6 +2244,141 @@ body.modal-open {
   background-size: 16px;
   padding-right: 2.75rem;
 }
+
+.form-field input:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: rgba(22, 60, 48, 0.55);
+  box-shadow: 0 0 0 4px rgba(22, 60, 48, 0.15);
+  background: #fff;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.button.primary-button {
+  background: #163c30;
+  color: #fff;
+  box-shadow: 0 18px 30px rgba(17, 40, 32, 0.18);
+}
+
+.button.primary-button:hover {
+  transform: translateY(-1px);
+}
+
+.button.cancel-button {
+  background: #f4e2bc;
+  color: #163c30;
+  border: 1px solid #d8c79f;
+}
+
+.button.cancel-button:hover {
+  background: #f0d8a5;
+}
+
+.documents-panel .documents-table {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.documents-row {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  background: #fbf5e7;
+  padding: 1.1rem 1.5rem;
+  border-radius: 20px;
+  box-shadow: inset 0 0 0 1px rgba(22, 60, 48, 0.05);
+}
+
+.documents-row .doc-title {
+  font-weight: 600;
+  flex: 1;
+}
+
+.status-badge {
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: #fff;
+  background: #1f5748;
+  padding: 0.4rem 1.2rem;
+  border-radius: 999px;
+}
+
+.button.doc-button {
+  background: #163c30;
+  color: #fff;
+  border-radius: 16px;
+  padding: 0.75rem 1.4rem;
+  box-shadow: 0 16px 30px rgba(17, 40, 32, 0.18);
+}
+
+.button.doc-button:hover {
+  transform: translateY(-1px);
+}
+
+.language-panel .language-preference {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: flex-end;
+}
+
+.language-panel .language-preference .form-field {
+  flex: 1 1 240px;
+}
+
+.language-panel .language-preference span {
+  font-weight: 600;
+  color: var(--color-forest-900);
+}
+
+.language-panel select {
+  min-height: 52px;
+}
+
+@media (max-width: 768px) {
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel-glyph {
+    width: 96px;
+  }
+
+  .form-actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .documents-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .button.doc-button {
+    width: 100%;
+  }
+}
+
 
 .visually-hidden {
   position: absolute !important;
@@ -3178,484 +3156,566 @@ body.modal-open {
   }
 }
 
+
 .individual-dashboard {
-  width: 100%;
-codex/update-individual-dashboard-layout-and-styles-rmlh06
-  --color-forest-900: #d9b65d;
-  --color-forest-800: #b48f36;
-  --color-forest-700: #8a6a1d;
-  --color-forest-100: #f5edd8;
-  --color-gold-200: #f0e0ba;
-  --color-gold-100: #fbf2d8;
-  --color-background: #fdf8ee;
-  --color-muted: #7b6a45;
-  --shadow-card: 0 24px 40px rgba(138, 106, 29, 0.16);
-  color: #3f3214;
-main
+  --sand-900: #3f3214;
+  --sand-800: #2f2512;
+  --sand-700: #8a6a1d;
+  --sand-500: #d9b65d;
+  --sand-300: #f3e3c3;
+  --sand-200: #f7ecd2;
+  --sand-100: #fbf2d8;
+  --text-muted: #7b6a45;
+  --card-shadow: 0 24px 40px rgba(138, 106, 29, 0.12);
+  min-height: 100vh;
+  display: flex;
+  background: var(--sand-100);
+  color: var(--sand-900);
 }
 
-.user-panel {
-  width: 340px;
-codex/update-individual-dashboard-layout-and-styles-rmlh06
-  background: linear-gradient(180deg, var(--color-forest-700) 0%, var(--color-forest-900) 100%);
-  color: #fdf9ed;
-
-  background: linear-gradient(180deg, var(--color-forest-900) 0%, var(--color-forest-700) 100%);
-  color: #f5fbf8;
-main
+.individual-dashboard__sidebar {
+  width: 320px;
+  padding: 3rem 2.5rem;
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  padding: 3rem 2.5rem;
-  border-top-right-radius: var(--radius-large);
-  border-bottom-right-radius: var(--radius-large);
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  box-shadow: inset -1px 0 0 rgba(253, 249, 237, 0.2);
-
-  box-shadow: inset -1px 0 0 rgba(245, 251, 248, 0.2);
-main
+  background: linear-gradient(180deg, #d9b65d 0%, #b48f36 100%);
+  color: #fdf9ed;
+  border-top-right-radius: 32px;
+  border-bottom-right-radius: 32px;
+  box-shadow: inset -1px 0 0 rgba(22, 18, 10, 0.18);
 }
 
-.user-panel__brand {
-  display: flex;
-  justify-content: center;
-}
-
-.user-panel__logo {
+.individual-dashboard__logo {
   max-width: 160px;
+  margin: 0 auto;
 }
 
-.user-panel__profile {
+.individual-dashboard__profile-card,
+.individual-dashboard__plan-card {
+  background: rgba(253, 249, 237, 0.18);
+  border-radius: 28px;
+  padding: 1.75rem;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(253, 249, 237, 0.25);
 }
 
-.user-panel__avatar-wrap {
-  width: 72px;
-  height: 72px;
-  border-radius: 20px;
+.individual-dashboard__profile-card {
+  align-items: center;
+  text-align: center;
+}
+
+.individual-dashboard__profile-avatar {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
   overflow: hidden;
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.28), inset 0 0 0 3px rgba(253, 249, 237, 0.45);
-
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.28), inset 0 0 0 3px rgba(245, 251, 248, 0.32);
- main
+  box-shadow: 0 18px 32px rgba(12, 9, 4, 0.28), inset 0 0 0 3px rgba(253, 249, 237, 0.55);
 }
 
-.user-panel__avatar {
+.individual-dashboard__profile-avatar-image {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.user-panel__identity {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+.individual-dashboard__profile-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: rgba(253, 249, 237, 0.72);
 }
 
-.user-panel__name {
+.individual-dashboard__profile-name {
   margin: 0;
-  font-size: 1.4rem;
-  font-weight: 700;
+  font-size: 1.5rem;
 }
 
-.user-panel__member {
+.individual-dashboard__profile-meta {
   margin: 0;
-codex/update-individual-dashboard-layout-and-styles-rmlh06
   color: rgba(253, 249, 237, 0.78);
-
-  color: rgba(245, 251, 248, 0.75);
- main
-  font-size: 0.95rem;
 }
 
-.user-panel__plan {
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  background: rgba(253, 249, 237, 0.16);
-
-  background: rgba(245, 251, 248, 0.12);
- main
-  border-radius: var(--radius-medium);
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  box-shadow: inset 0 0 0 1px rgba(253, 249, 237, 0.25);
-
-  box-shadow: inset 0 0 0 1px rgba(245, 251, 248, 0.18);
-main
-}
-
-.user-panel__plan-header {
+.individual-dashboard__plan-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   font-size: 0.85rem;
-  letter-spacing: 0.02em;
   text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
-.user-panel__plan-label {
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  color: rgba(253, 249, 237, 0.72);
-
-  color: rgba(245, 251, 248, 0.72);
- main
+.individual-dashboard__plan-label {
+  color: rgba(253, 249, 237, 0.75);
 }
 
-.user-panel__plan-status {
-  padding: 0.2rem 0.8rem;
+.individual-dashboard__plan-status {
+  padding: 0.25rem 0.85rem;
   border-radius: 999px;
-codex/update-individual-dashboard-layout-and-styles-rmlh06
-  background: rgba(253, 249, 237, 0.28);
-  color: #2d1a06;
-
-  background: rgba(245, 251, 248, 0.2);
- main
+  background: rgba(253, 249, 237, 0.26);
+  color: #2f2512;
   font-weight: 600;
 }
 
-.user-panel__plan-name {
+.individual-dashboard__plan-name {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.3rem;
 }
 
-.user-panel__plan-meta {
+.individual-dashboard__plan-meta {
   margin: 0;
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  color: rgba(253, 249, 237, 0.78);
-
-  color: rgba(245, 251, 248, 0.75);
- main
+  color: rgba(253, 249, 237, 0.75);
 }
 
-.user-panel__stats {
+.individual-dashboard__plan-list {
+  margin: 0;
   display: grid;
-  gap: 1.25rem;
+  gap: 0.75rem;
+  font-size: 0.95rem;
 }
 
-.user-panel__stat {
+.individual-dashboard__plan-list div {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(253, 249, 237, 0.85);
+}
+
+.individual-dashboard__plan-list dt {
+  margin: 0;
+  font-weight: 600;
+}
+
+.individual-dashboard__plan-list dd {
+  margin: 0;
+}
+
+.individual-dashboard__menu {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-}
-
-.user-panel__stat-label {
-  font-size: 0.9rem;
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  color: rgba(253, 249, 237, 0.78);
-
-  color: rgba(245, 251, 248, 0.75);
-main
-}
-
-.user-panel__stat-value {
-  font-weight: 600;
-  font-size: 1.05rem;
-}
-
-.user-panel__actions,
-.user-panel__secondary-actions {
-  display: grid;
   gap: 0.75rem;
 }
 
-.user-panel .button {
-  width: 100%;
+.individual-dashboard__menu a {
+  padding: 0.85rem 1.1rem;
+  border-radius: 16px;
+  color: rgba(253, 249, 237, 0.85);
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.user-panel .outline-button {
- codex/update-individual-dashboard-layout-and-styles-rmlh06
-  border-color: rgba(253, 249, 237, 0.55);
+.individual-dashboard__menu a.active,
+.individual-dashboard__menu a:hover {
+  background: rgba(253, 249, 237, 0.22);
+  color: #fff;
+}
+
+.individual-dashboard__sidebar-footer {
+  margin-top: auto;
+}
+
+.individual-dashboard__sidebar-footer .button {
+  width: 100%;
+  border: 1px solid rgba(253, 249, 237, 0.45);
   color: #fdf9ed;
 }
 
-.user-panel .outline-button:hover {
+.individual-dashboard__sidebar-footer .button:hover {
   background: rgba(253, 249, 237, 0.18);
 }
 
-.individual-dashboard .button:focus-visible {
-  outline: 3px solid rgba(138, 106, 29, 0.45);
-}
-
-.individual-dashboard .solid-button {
-  background: #d9b65d;
-  color: #2d1a06;
-  box-shadow: 0 16px 30px rgba(97, 74, 12, 0.24);
-}
-
-.individual-dashboard .solid-button:hover {
-  transform: translateY(-1px);
-  background: #e2c570;
-}
-
-.individual-dashboard .outline-button {
-  background: transparent;
-  color: #8a6a1d;
-  border: 2px solid rgba(138, 106, 29, 0.4);
-}
-
-.individual-dashboard .outline-button:hover {
-  background: rgba(217, 182, 93, 0.14);
-}
-
-.individual-dashboard .ghost-button {
-  background: rgba(217, 182, 93, 0.12);
-  color: #8a6a1d;
-}
-
-.individual-dashboard .ghost-button:hover {
-  background: rgba(217, 182, 93, 0.2);
-}
-
-.user-panel .solid-button {
-  background: rgba(253, 249, 237, 0.22);
-  color: #fdf9ed;
-  box-shadow: 0 16px 30px rgba(47, 26, 6, 0.22);
-}
-
-.user-panel .solid-button:hover {
-  background: rgba(253, 249, 237, 0.32);
-
-  border-color: rgba(245, 251, 248, 0.45);
-  color: #f5fbf8;
-}
-
-.user-panel .outline-button:hover {
-  background: rgba(245, 251, 248, 0.12);
- main
-}
-
-.dashboard-main {
+.individual-dashboard__main {
   flex: 1;
   padding: 3rem 4rem;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2.75rem;
 }
 
-.dashboard-main__header {
+.individual-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+  background: linear-gradient(135deg, rgba(217, 182, 93, 0.18) 0%, rgba(217, 182, 93, 0.05) 100%);
+  border-radius: 32px;
+  padding: 2.25rem 2.5rem;
+  box-shadow: inset 0 0 0 1px rgba(138, 106, 29, 0.12);
+}
+
+.individual-hero__info {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.individual-hero__avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  overflow: hidden;
+  box-shadow: 0 20px 36px rgba(138, 106, 29, 0.26);
+}
+
+.individual-hero__avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.individual-hero__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.individual-hero__title {
+  margin: 0;
+  font-size: 2.2rem;
+}
+
+.individual-hero__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  max-width: 520px;
+}
+
+.individual-hero__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.individual-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.metric-card {
+  background: #fff;
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: var(--card-shadow);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-.dashboard-main__eyebrow {
+.metric-card__label {
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 600;
-  color: var(--color-muted);
-  margin: 0;
+  color: var(--text-muted);
 }
 
-.dashboard-main__title {
-  margin: 0;
-  font-size: 2rem;
+.metric-card__value {
+  font-size: 1.65rem;
   font-weight: 700;
 }
 
-.dashboard-main__subtitle {
-  margin: 0;
-  color: var(--color-muted);
-  max-width: 520px;
+.metric-card__value--success {
+  color: #2f7a3c;
 }
 
-.info-grid {
+.metric-card__meta {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.individual-content {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 2rem;
 }
 
-.info-card {
+.individual-content .panel {
   background: #fff;
-  border-radius: var(--radius-large);
+  border-radius: 28px;
   padding: 2rem;
+  box-shadow: var(--card-shadow);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  box-shadow: var(--shadow-card);
+  gap: 1.75rem;
 }
 
-.info-card--wide {
-  grid-column: span 2;
-}
-
-.info-card__header {
+.panel__header {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.info-card__title {
+.panel__title {
   margin: 0;
-  font-size: 1.35rem;
-  font-weight: 700;
+  font-size: 1.4rem;
 }
 
-.info-card__subtitle {
+.panel__subtitle {
   margin: 0;
-  color: var(--color-muted);
+  color: var(--text-muted);
 }
 
-.info-list {
+.tasks-list {
   margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.tasks-list__item {
   display: grid;
+  grid-template-columns: auto 1fr auto;
   gap: 1rem;
-}
-
-.info-list__item {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.info-list__item dt {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-muted);
-}
-
-.info-list__item dd {
-  margin: 0;
-  font-weight: 600;
-}
-
-.info-card__button {
-  align-self: flex-start;
-}
-
-.documents-list {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.document-row {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: center;
 }
 
-.document-row__details h4 {
-  margin: 0;
+.tasks-list__badge {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--sand-500);
+  color: #fff;
+  font-weight: 700;
+}
+
+.tasks-list__content h3 {
+  margin: 0 0 0.35rem;
   font-size: 1.05rem;
 }
 
-.document-row__details p {
-  margin: 0.35rem 0 0;
-  color: var(--color-muted);
+.tasks-list__content p {
+  margin: 0;
+  color: var(--text-muted);
 }
 
-.document-row__meta {
+.beneficiary-card {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.9rem;
+  gap: 0.5rem;
+  background: var(--sand-200);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(138, 106, 29, 0.15);
 }
 
-.document-row__timestamp {
-  color: var(--color-muted);
+.beneficiary-card__name {
+  margin: 0;
+  font-size: 1.2rem;
 }
 
-.document-row__action {
-  justify-self: flex-end;
+.beneficiary-card__relation,
+.beneficiary-card__contact {
+  margin: 0;
+  color: var(--text-muted);
 }
 
-.status-pill {
-  display: inline-flex;
+.beneficiary-card__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.panel--documents .documents-status {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.documents-status__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 1rem;
   align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.85rem;
+}
+
+.documents-status__info h3 {
+  margin: 0;
+}
+
+.documents-status__info p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+}
+
+.individual-dashboard .status-pill {
+  padding: 0.4rem 1rem;
   border-radius: 999px;
-  font-weight: 600;
   font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.status-pill--success {
-  background: rgba(46, 204, 113, 0.18);
-  color: #1f6840;
-}
-
-.status-pill--warning {
-  background: rgba(249, 214, 46, 0.2);
-  color: #8c6a05;
-}
-
-.status-pill--neutral {
-  background: rgba(85, 106, 97, 0.15);
-  color: var(--color-muted);
-}
-
-.language-card {
-  background: var(--color-gold-100);
-  border-radius: var(--radius-medium);
-  padding: 1.25rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  box-shadow: inset 0 0 0 1px rgba(31, 87, 72, 0.12);
-}
-
-.language-card__label {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-muted);
-}
-
-.language-card__value {
   font-weight: 700;
-  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-codex/update-individual-dashboard-layout-and-styles-rmlh06
 .individual-dashboard .status-pill--success {
-  background: rgba(217, 182, 93, 0.18);
-  color: #7a5d12;
+  background: rgba(65, 160, 98, 0.18);
+  color: #2f7a3c;
+}
+
+.individual-dashboard .status-pill--warning {
+  background: rgba(217, 182, 93, 0.2);
+  color: #8a6a1d;
 }
 
 .individual-dashboard .status-pill--neutral {
-  background: rgba(123, 106, 69, 0.16);
-  color: #7b6a45;
+  background: rgba(123, 106, 69, 0.18);
+  color: var(--text-muted);
 }
 
-.individual-dashboard .language-card {
+.panel--documents .button,
+.tasks-list .button,
+.support-grid .button {
+  white-space: nowrap;
+}
+
+.panel--wide {
+  grid-column: span 2;
+}
+
+.support-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.support-grid__item {
+  background: var(--sand-200);
+  border-radius: 22px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   box-shadow: inset 0 0 0 1px rgba(138, 106, 29, 0.12);
 }
 
- main
+.support-grid__item h3 {
+  margin: 0;
+}
+
+.support-grid__item p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
 @media (max-width: 1200px) {
-  .dashboard {
+  .individual-dashboard {
     flex-direction: column;
   }
 
-  .user-panel {
+  .individual-dashboard__sidebar {
     width: 100%;
-    border-radius: 0 0 var(--radius-large) var(--radius-large);
+    border-radius: 0 0 32px 32px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1.5rem;
   }
 
-  .dashboard-main {
-    padding: 2.5rem 2rem;
+  .individual-dashboard__brand {
+    width: 100%;
   }
 
-  .info-grid {
-    grid-template-columns: 1fr;
+  .individual-dashboard__profile-card,
+  .individual-dashboard__plan-card {
+    flex: 1 1 280px;
   }
 
-  .info-card--wide {
-    grid-column: span 1;
+  .individual-dashboard__menu {
+    flex-direction: row;
+    flex-wrap: wrap;
   }
 
-  .document-row {
-    grid-template-columns: 1fr;
+  .individual-dashboard__menu a {
+    flex: 1 1 180px;
+    text-align: center;
   }
 
-  .document-row__action {
-    justify-self: flex-start;
+  .individual-dashboard__sidebar-footer {
+    width: 100%;
+  }
+
+  .individual-dashboard__main {
+    padding: 2.5rem 2rem 3rem;
+  }
+
+  .support-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+@media (max-width: 900px) {
+  .individual-hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .individual-hero__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .individual-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .individual-content {
+    grid-template-columns: 1fr;
+  }
+
+  .panel--wide {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .individual-dashboard__sidebar {
+    padding: 2rem 1.5rem 2.5rem;
+  }
+
+  .individual-hero__info {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .individual-hero__avatar {
+    width: 80px;
+    height: 80px;
+  }
+
+  .individual-hero__title {
+    font-size: 1.9rem;
+  }
+
+  .individual-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .documents-status__item {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tasks-list__item {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-auto-flow: row;
+  }
+
+  .tasks-list__item .button {
+    grid-column: 1 / -1;
+    justify-self: flex-start;
+  }
+
+  .support-grid {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/images/avatar-default.svg
+++ b/images/avatar-default.svg
@@ -1,0 +1,5 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="80" fill="#D9B65D"/>
+  <path d="M80 78C92.1503 78 102 68.1503 102 56C102 43.8497 92.1503 34 80 34C67.8497 34 58 43.8497 58 56C58 68.1503 67.8497 78 80 78Z" fill="#FDF8EE"/>
+  <path d="M40 126C40 105.909 56.9086 89 77 89H83C103.091 89 120 105.909 120 126V134H40V126Z" fill="#FDF8EE"/>
+</svg>

--- a/individual-dashboard.html
+++ b/individual-dashboard.html
@@ -10,159 +10,189 @@
   <link rel="stylesheet" href="dashboard.css">
 </head>
 <body>
-  <div class="dashboard individual-dashboard">
-    <aside class="user-panel">
-      <div class="user-panel__brand">
-        <img src="images/logo-white.png" alt="MallowCare Logo" class="user-panel__logo">
+  <div class="individual-dashboard">
+    <aside class="individual-dashboard__sidebar">
+      <div class="individual-dashboard__brand">
+        <img src="images/imagen blanca.png" alt="Wellbeing logo" class="individual-dashboard__logo">
       </div>
-      <div class="user-panel__profile">
-        <div class="user-panel__avatar-wrap">
-          <img src="images/foto_personal(1).jpg" alt="Profile picture" class="user-panel__avatar">
+      <div class="individual-dashboard__profile-card">
+        <div class="individual-dashboard__profile-avatar">
+          <img src="images/avatar-default.svg" alt="Avatar del usuario" class="individual-dashboard__profile-avatar-image" data-user-avatar>
         </div>
-        <div class="user-panel__identity">
-          <h1 class="user-panel__name">Maria Rodriguez</h1>
-          <p class="user-panel__member" data-i18n-key="profile_member_since">Member since March 2023</p>
-        </div>
-      </div>
-      <div class="user-panel__plan">
-        <div class="user-panel__plan-header">
-          <span class="user-panel__plan-label" data-i18n-key="profile_status_plan_label">Plan</span>
-          <span class="user-panel__plan-status" data-i18n-key="plan_status_value">ACTIVE</span>
-        </div>
-        <h2 class="user-panel__plan-name" data-i18n-key="profile_status_plan_value">Family Protect Plus</h2>
-        <p class="user-panel__plan-meta" data-i18n-key="profile_status_coverage_meta">Medical · Vision · Dental</p>
-      </div>
-      <div class="user-panel__stats">
-        <div class="user-panel__stat">
-          <span class="user-panel__stat-label" data-i18n-key="coverage_title">Your Coverage</span>
-          <span class="user-panel__stat-value" data-i18n-key="coverage_value">Up to $100,000</span>
-        </div>
-        <div class="user-panel__stat">
-          <span class="user-panel__stat-label" data-i18n-key="next_payment_title">Next Payment</span>
-          <span class="user-panel__stat-value" data-i18n-key="next_payment_value">Due Oct 15, 2025</span>
+        <div class="individual-dashboard__profile-text">
+          <p class="individual-dashboard__profile-eyebrow">Miembro individual</p>
+          <h2 class="individual-dashboard__profile-name"><span data-user-name>Maria Thompson</span></h2>
+          <p class="individual-dashboard__profile-meta">Miembro desde marzo 2023</p>
         </div>
       </div>
-      <div class="user-panel__actions">
-        <button class="button solid-button" data-i18n-key="manage_plan_button">Manage My Plan</button>
-        <button class="button ghost-button" data-i18n-key="update_profile_button">Update My Profile</button>
+      <div class="individual-dashboard__plan-card">
+        <header class="individual-dashboard__plan-header">
+          <span class="individual-dashboard__plan-label">Plan actual</span>
+          <span class="individual-dashboard__plan-status">Activo</span>
+        </header>
+        <h3 class="individual-dashboard__plan-name">Family Protect Plus</h3>
+        <p class="individual-dashboard__plan-meta">Salud • Visión • Dental</p>
+        <dl class="individual-dashboard__plan-list">
+          <div>
+            <dt>Cobertura</dt>
+            <dd>Hasta $100,000</dd>
+          </div>
+          <div>
+            <dt>Próximo pago</dt>
+            <dd>15 Oct 2025</dd>
+          </div>
+        </dl>
+        <button class="button ghost-button">Ver detalles</button>
       </div>
-      <div class="user-panel__secondary-actions">
-        <button class="button outline-button" data-i18n-key="add_family_member_button">Add a Family Member</button>
-        <button class="button outline-button" data-i18n-key="manage_alerts_button">Manage Alerts</button>
+      <nav class="individual-dashboard__menu">
+        <a class="active" href="individual-dashboard.html">Inicio</a>
+        <a href="my-profile.html">Mi perfil</a>
+        <a href="manage-my-plan.html">Mi plan</a>
+        <a href="payments.html">Pagos</a>
+        <a href="settings.html">Ajustes</a>
+      </nav>
+      <div class="individual-dashboard__sidebar-footer">
+        <button class="button outline-button logout">Cerrar sesión</button>
       </div>
     </aside>
-    <main class="dashboard-main">
-      <header class="dashboard-main__header">
-        <p class="dashboard-main__eyebrow" data-i18n-key="profile_account_center">Account Center</p>
-        <h2 class="dashboard-main__title" data-i18n-key="dashboard_welcome_back">Welcome back, Maria</h2>
-        <p class="dashboard-main__subtitle" data-i18n-key="profile_overview_subtitle">Review your coverage health, upcoming payments, and quick tasks in one place.</p>
+    <main class="individual-dashboard__main">
+      <header class="individual-hero">
+        <div class="individual-hero__info">
+          <div class="individual-hero__avatar">
+            <img src="images/avatar-default.svg" alt="Avatar del usuario" class="individual-hero__avatar-image" data-user-avatar>
+          </div>
+          <div class="individual-hero__copy">
+            <p class="individual-hero__eyebrow">Bienvenida de nuevo</p>
+            <h1 class="individual-hero__title"><span data-user-name>Maria Thompson</span></h1>
+            <p class="individual-hero__subtitle">Tu plan Family Protect Plus está activo y cubre atención médica, visión y dental para toda tu familia.</p>
+          </div>
+        </div>
+        <div class="individual-hero__actions">
+          <button class="button solid-button">Gestionar mi plan</button>
+          <button class="button ghost-button">Actualizar mis datos</button>
+        </div>
       </header>
-      <div class="info-grid">
-        <section class="info-card">
-          <div class="info-card__header">
-            <h3 class="info-card__title" data-i18n-key="profile_personal_details_title">Personal Details</h3>
-            <p class="info-card__subtitle" data-i18n-key="profile_personal_details_subtitle">Update your contact information so we can reach you without delays.</p>
-          </div>
-          <dl class="info-list">
-            <div class="info-list__item">
-              <dt data-i18n-key="form_email_address">Email Address</dt>
-              <dd>maria.rodriguez@email.com</dd>
-            </div>
-            <div class="info-list__item">
-              <dt data-i18n-key="form_phone_number">Phone Number</dt>
-              <dd>+1 (312) 555-0198</dd>
-            </div>
-            <div class="info-list__item">
-              <dt data-i18n-key="form_address1">Address Line 1</dt>
-              <dd>4210 Maple Avenue</dd>
-            </div>
-            <div class="info-list__item">
-              <dt data-i18n-key="form_city">City</dt>
-              <dd>Chicago, IL 60647</dd>
-            </div>
-          </dl>
-          <button class="button ghost-button info-card__button" data-i18n-key="update_profile_button">Update My Profile</button>
-        </section>
-        <section class="info-card">
-          <div class="info-card__header">
-            <h3 class="info-card__title" data-i18n-key="profile_beneficiary_title">My Beneficiary</h3>
-            <p class="info-card__subtitle" data-i18n-key="profile_beneficiary_subtitle">Share who should receive your benefits and how to contact them.</p>
-          </div>
-          <dl class="info-list">
-            <div class="info-list__item">
-              <dt data-i18n-key="form_full_name">Full Name</dt>
-              <dd>Andres Rodriguez</dd>
-            </div>
-            <div class="info-list__item">
-              <dt data-i18n-key="form_relationship">Relationship</dt>
-              <dd data-i18n-key="option_spouse">Spouse</dd>
-            </div>
-            <div class="info-list__item">
-              <dt data-i18n-key="form_phone_number">Phone Number</dt>
-              <dd>+1 (312) 555-3421</dd>
-            </div>
-            <div class="info-list__item">
-              <dt data-i18n-key="form_percentage_allocation">Percentage Allocation</dt>
-              <dd>100%</dd>
-            </div>
-          </dl>
-          <button class="button ghost-button info-card__button" data-i18n-key="button_save_beneficiary">Save Beneficiary</button>
-        </section>
-        <section class="info-card info-card--wide">
-          <div class="info-card__header">
-            <h3 class="info-card__title" data-i18n-key="profile_documents_title">Identification Documents</h3>
-            <p class="info-card__subtitle" data-i18n-key="profile_documents_subtitle">Upload current identification so we can verify your eligibility and beneficiary claims.</p>
-          </div>
-          <div class="documents-list">
-            <div class="document-row">
-              <div class="document-row__details">
-                <h4 data-i18n-key="doc_passport">Passport</h4>
-                <p data-i18n-key="doc_passport_subtitle">Upload a clear scan of the picture page.</p>
+      <section class="individual-metrics">
+        <article class="metric-card">
+          <span class="metric-card__label">Estado del plan</span>
+          <span class="metric-card__value metric-card__value--success">Activo</span>
+          <p class="metric-card__meta">Renovado el 18 de abril de 2025</p>
+        </article>
+        <article class="metric-card">
+          <span class="metric-card__label">Cobertura disponible</span>
+          <span class="metric-card__value">$100,000</span>
+          <p class="metric-card__meta">Incluye servicios de salud, visión y dental</p>
+        </article>
+        <article class="metric-card">
+          <span class="metric-card__label">Próximo pago</span>
+          <span class="metric-card__value">15 Oct 2025</span>
+          <p class="metric-card__meta">Cargo automático programado</p>
+        </article>
+      </section>
+      <section class="individual-content">
+        <article class="panel">
+          <header class="panel__header">
+            <h2 class="panel__title">Tareas rápidas</h2>
+            <p class="panel__subtitle">Completa estas acciones sugeridas para mantener tu plan al día.</p>
+          </header>
+          <ul class="tasks-list">
+            <li class="tasks-list__item">
+              <span class="tasks-list__badge">1</span>
+              <div class="tasks-list__content">
+                <h3>Agregar beneficiario secundario</h3>
+                <p>Agrega un contacto alternativo para acelerar cualquier reclamo.</p>
               </div>
-              <div class="document-row__meta">
-                <span class="status-pill status-pill--success" data-i18n-key="option_uploaded">Uploaded</span>
-                <span class="document-row__timestamp" data-i18n-key="form_last_updated">Last Updated</span>
-                <time>Apr 02, 2025</time>
+              <button class="button outline-button">Agregar</button>
+            </li>
+            <li class="tasks-list__item">
+              <span class="tasks-list__badge">2</span>
+              <div class="tasks-list__content">
+                <h3>Subir comprobante de residencia</h3>
+                <p>Verifica que tu dirección esté actualizada para recibir correspondencia.</p>
               </div>
-              <button class="button outline-button document-row__action" data-i18n-key="button_upload_replace">Upload / Replace Document</button>
-            </div>
-            <div class="document-row">
-              <div class="document-row__details">
-                <h4 data-i18n-key="doc_drivers_license">Driver's License</h4>
-                <p data-i18n-key="doc_drivers_license_subtitle">Ensure the address matches your current residence.</p>
+              <button class="button outline-button">Subir</button>
+            </li>
+            <li class="tasks-list__item">
+              <span class="tasks-list__badge">3</span>
+              <div class="tasks-list__content">
+                <h3>Configurar alertas de pago</h3>
+                <p>Recibe recordatorios por correo o SMS antes de cada vencimiento.</p>
               </div>
-              <div class="document-row__meta">
-                <span class="status-pill status-pill--warning" data-i18n-key="option_expiring">Expiring Soon</span>
-                <span class="document-row__timestamp" data-i18n-key="form_expiration_date">Expiration Date</span>
-                <time>Aug 14, 2025</time>
-              </div>
-              <button class="button outline-button document-row__action" data-i18n-key="button_upload_replace">Upload / Replace Document</button>
-            </div>
-            <div class="document-row">
-              <div class="document-row__details">
-                <h4 data-i18n-key="doc_ssn">Social Security</h4>
-                <p data-i18n-key="doc_ssn_subtitle">Required for beneficiary payouts and tax reporting.</p>
-              </div>
-              <div class="document-row__meta">
-                <span class="status-pill status-pill--neutral" data-i18n-key="option_not_submitted">Not Submitted</span>
-                <span class="document-row__timestamp" data-i18n-key="placeholder_no_document">No document uploaded</span>
-              </div>
-              <button class="button outline-button document-row__action" data-i18n-key="button_upload">Upload Document</button>
+              <button class="button outline-button">Configurar</button>
+            </li>
+          </ul>
+        </article>
+        <article class="panel">
+          <header class="panel__header">
+            <h2 class="panel__title">Beneficiarios</h2>
+            <p class="panel__subtitle">Gestiona quién recibirá tu cobertura si la necesitas.</p>
+          </header>
+          <div class="beneficiary-card">
+            <h3 class="beneficiary-card__name">Andrés Rodriguez</h3>
+            <p class="beneficiary-card__relation">Cónyuge • 100% asignado</p>
+            <p class="beneficiary-card__contact">+1 (312) 555-3421 • andres.rodriguez@email.com</p>
+            <div class="beneficiary-card__actions">
+              <button class="button ghost-button">Actualizar datos</button>
+              <button class="button outline-button">Cambiar porcentaje</button>
             </div>
           </div>
-        </section>
-        <section class="info-card">
-          <div class="info-card__header">
-            <h3 class="info-card__title" data-i18n-key="profile_language_title">Language Preference</h3>
-            <p class="info-card__subtitle" data-i18n-key="profile_language_description">Your updates and care team messages will arrive in this language.</p>
+        </article>
+        <article class="panel panel--documents">
+          <header class="panel__header">
+            <h2 class="panel__title">Documentos de identidad</h2>
+            <p class="panel__subtitle">Tu verificación está casi completa, solo falta un documento.</p>
+          </header>
+          <ul class="documents-status">
+            <li class="documents-status__item">
+              <div class="documents-status__info">
+                <h3>Pasaporte</h3>
+                <p>Subido el 2 de abril de 2025</p>
+              </div>
+              <span class="status-pill status-pill--success">Aprobado</span>
+              <button class="button ghost-button">Reemplazar</button>
+            </li>
+            <li class="documents-status__item">
+              <div class="documents-status__info">
+                <h3>Licencia de conducir</h3>
+                <p>Vence el 14 de agosto de 2025</p>
+              </div>
+              <span class="status-pill status-pill--warning">Por vencer</span>
+              <button class="button ghost-button">Actualizar</button>
+            </li>
+            <li class="documents-status__item">
+              <div class="documents-status__info">
+                <h3>Tarjeta de seguro social</h3>
+                <p>No se ha cargado ningún archivo</p>
+              </div>
+              <span class="status-pill status-pill--neutral">Pendiente</span>
+              <button class="button ghost-button">Subir</button>
+            </li>
+          </ul>
+        </article>
+        <article class="panel panel--wide">
+          <header class="panel__header">
+            <h2 class="panel__title">Soporte y próximos pasos</h2>
+            <p class="panel__subtitle">Tu equipo de cuidado está disponible para ayudarte cuando lo necesites.</p>
+          </header>
+          <div class="support-grid">
+            <div class="support-grid__item">
+              <h3>Agenda una llamada</h3>
+              <p>Coordina una reunión virtual con un especialista de bienestar familiar.</p>
+              <button class="button solid-button">Reservar</button>
+            </div>
+            <div class="support-grid__item">
+              <h3>Mensajes seguros</h3>
+              <p>Revisa la bandeja de entrada para responder a tu enfermera de cabecera.</p>
+              <button class="button outline-button">Ir a mensajes</button>
+            </div>
+            <div class="support-grid__item">
+              <h3>Centro de ayuda</h3>
+              <p>Encuentra guías y preguntas frecuentes sobre coberturas y reembolsos.</p>
+              <button class="button ghost-button">Ver artículos</button>
+            </div>
           </div>
-          <div class="language-card">
-            <span class="language-card__label" data-i18n-key="profile_language_label">Preferred language</span>
-            <span class="language-card__value" data-i18n-key="lang_english">English</span>
-          </div>
-          <button class="button ghost-button info-card__button" data-i18n-key="button_update_preference">Update Preference</button>
-        </section>
-      </div>
+        </article>
+      </section>
     </main>
   </div>
   <script src="i18n.js"></script>

--- a/my-profile.html
+++ b/my-profile.html
@@ -13,7 +13,7 @@
   <div class="dashboard new-dashboard">
     <aside class="sidebar new-sidebar">
       <div class="logo-container">
-        <img src="images/logo-white.png" alt="MallowCare Logo" class="sidebar-logo">
+        <img src="images/WB%20Fondo%20blanco%20-%20Color.png" alt="MallowCare Logo" class="sidebar-logo">
       </div>
       <nav class="menu new-menu">
         <a href="individual-dashboard.html"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-grid"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg> <span data-i18n-key="sidebar_dashboard">Dashboard</span></a>
@@ -86,230 +86,193 @@
               <p class="member-since" data-i18n-key="profile_member_since">Member since March 2023</p>
             </header>
 
-            <section class="info-card personal-card">
-              <div class="card-header">
-                <div>
+            <section class="profile-panel personal-panel">
+              <div class="panel-header">
+                <div class="panel-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false">
+                    <circle cx="48" cy="48" r="47" fill="#f4e2bc" />
+                    <path d="M58.9 28.3c-8.8 0-13 6.1-13 12.5 0 5.8 4.8 11 12.4 11 7.4 0 12.1-5.2 12.1-11.3 0-6.5-4.6-12.2-11.5-12.2zm-24 2.8c-6.8 0-11.4 4.8-11.4 11 0 5.5 3.8 9.4 9.5 11.6l6.9 2.6c8.8 3.3 13.5 7.4 13.5 15 0 7.1-5.5 13.4-15.5 13.4-8.8 0-15.6-5.4-15.6-12.6 0-5 3.5-9.9 9.7-11.8" fill="none" stroke="#163c30" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </div>
+                <div class="panel-copy">
                   <h2 data-i18n-key="profile_personal_details_title">Personal Details</h2>
-                  <p data-i18n-key="profile_personal_details_subtitle">Update your contact information so we can reach you without delays.</p>
+                  <p data-i18n-key="profile_personal_details_subtitle">Keep your details current so we can reach you when it matters most.</p>
                 </div>
               </div>
-              <form id="personalForm" class="details-form" autocomplete="on">
-                <div class="form-grid two-column">
+              <form id="personalForm" class="panel-form" autocomplete="on">
+                <fieldset class="form-group">
+                  <legend>Full Name</legend>
+                  <div class="field-pair">
+                    <label class="form-field">
+                      <span class="sr-only">First Name</span>
+                      <input type="text" name="firstName" value="Maria" autocomplete="given-name" required>
+                    </label>
+                    <label class="form-field">
+                      <span class="sr-only">Last Name</span>
+                      <input type="text" name="lastName" value="Thompson" autocomplete="family-name" required>
+                    </label>
+                  </div>
+                </fieldset>
+                <div class="field-grid">
                   <label class="form-field">
-                    <span data-i18n-key="form_first_name">First Name</span>
-                    <input type="text" name="firstName" value="Maria" autocomplete="given-name" required>
+                    <span>Email address*</span>
+                    <input type="email" name="emailAddress" value="maria@email.com" autocomplete="email" required>
                   </label>
                   <label class="form-field">
-                    <span data-i18n-key="form_last_name">Last Name</span>
-                    <input type="text" name="lastName" value="Thompson" autocomplete="family-name" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_email_address">Email Address</span>
-                    <input type="email" name="emailAddress" value="maria.thompson@email.com" autocomplete="email" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_phone_number">Phone Number</span>
-                    <input type="tel" name="phoneNumber" value="+1 (512) 555-0198" autocomplete="tel" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_dob">Date of Birth</span>
-                    <input type="date" name="dob" value="1990-06-18" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_member_id">Member ID</span>
-                    <input type="text" name="memberId" value="MC-204587" autocomplete="off" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_address1">Address Line 1</span>
-                    <input type="text" name="address1" value="123 Garden Avenue" autocomplete="address-line1" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_address2">Address Line 2</span>
-                    <input type="text" name="address2" value="Unit 5B" autocomplete="address-line2">
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_city">City</span>
-                    <input type="text" name="city" value="Austin" autocomplete="address-level2" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_state">State</span>
-                    <input type="text" name="state" value="TX" autocomplete="address-level1" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_postal_code">Postal Code</span>
-                    <input type="text" name="postalCode" value="78704" autocomplete="postal-code" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_contact_method">Preferred Contact Method</span>
-                    <select name="contactMethod">
-                      <option value="email" data-i18n-key="option_email">Email</option>
-                      <option value="phone" data-i18n-key="option_phone">Phone</option>
-                      <option value="text" data-i18n-key="option_sms">Text message</option>
-                    </select>
+                    <span>Phone</span>
+                    <input type="tel" name="phoneNumber" value="+1 555-123-4567" autocomplete="tel" required>
                   </label>
                 </div>
+                <fieldset class="form-group">
+                  <legend>Address</legend>
+                  <label class="form-field">
+                    <span class="sr-only">Street Address</span>
+                    <input type="text" name="address1" value="123 Main Street" autocomplete="address-line1" required>
+                  </label>
+                  <label class="form-field">
+                    <span class="sr-only">Apartment, suite, etc.</span>
+                    <input type="text" name="address2" placeholder="Address Line 2" autocomplete="address-line2">
+                  </label>
+                  <div class="field-pair">
+                    <label class="form-field">
+                      <span class="sr-only">City</span>
+                      <input type="text" name="city" value="Miami" autocomplete="address-level2" required>
+                    </label>
+                    <label class="form-field">
+                      <span class="sr-only">State</span>
+                      <select name="state" autocomplete="address-level1" required>
+                        <option value="" disabled>State</option>
+                        <option value="FL" selected>Florida</option>
+                        <option value="TX">Texas</option>
+                        <option value="CA">California</option>
+                        <option value="NY">New York</option>
+                      </select>
+                    </label>
+                  </div>
+                  <label class="form-field">
+                    <span class="sr-only">Postal Code</span>
+                    <input type="text" name="postalCode" value="33101" autocomplete="postal-code" required>
+                  </label>
+                </fieldset>
                 <div class="form-actions">
-                  <button type="button" class="button outline-button" data-action="cancel" data-i18n-key="button_cancel">Cancel</button>
-                  <button type="submit" class="button solid-button" data-i18n-key="button_save_changes">Save Changes</button>
+                  <button type="button" class="button cancel-button" data-action="cancel" data-i18n-key="button_cancel">Cancel</button>
+                  <button type="submit" class="button primary-button" data-i18n-key="button_save_changes">Save Changes</button>
                 </div>
               </form>
             </section>
 
-            <section class="info-card beneficiary-card">
-              <div class="card-header">
-                <div>
+            <section class="profile-panel beneficiary-panel">
+              <div class="panel-header">
+                <div class="panel-copy">
                   <h2 data-i18n-key="profile_beneficiary_title">My Beneficiary</h2>
-                  <p data-i18n-key="profile_beneficiary_subtitle">Share who should receive your benefits and how to contact them.</p>
+                  <p data-i18n-key="profile_beneficiary_subtitle">Name the trusted person who will receive your plan's benefits if something happens to you.</p>
                 </div>
               </div>
-              <form id="beneficiaryForm" class="details-form" autocomplete="on">
-                <div class="form-grid two-column">
+              <form id="beneficiaryForm" class="panel-form" autocomplete="on">
+                <fieldset class="form-group">
+                  <legend>Full Name</legend>
+                  <div class="field-pair">
+                    <label class="form-field">
+                      <span class="sr-only">First Name</span>
+                      <input type="text" name="beneficiaryFirstName" value="Maria" autocomplete="given-name" required>
+                    </label>
+                    <label class="form-field">
+                      <span class="sr-only">Last Name</span>
+                      <input type="text" name="beneficiaryLastName" value="Thompson" autocomplete="family-name" required>
+                    </label>
+                  </div>
+                </fieldset>
+                <div class="field-grid">
                   <label class="form-field">
-                    <span data-i18n-key="form_full_name">Full Name</span>
-                    <input type="text" name="beneficiaryName" value="Diego Thompson" autocomplete="name" required>
+                    <span>Email address*</span>
+                    <input type="email" name="beneficiaryEmail" value="maria@email.com" autocomplete="email" required>
                   </label>
                   <label class="form-field">
-                    <span data-i18n-key="form_relationship">Relationship</span>
-                    <input type="text" name="beneficiaryRelationship" value="Brother" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_email_address">Email Address</span>
-                    <input type="email" name="beneficiaryEmail" value="diego.thompson@email.com" autocomplete="email">
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_phone_number">Phone Number</span>
-                    <input type="tel" name="beneficiaryPhone" value="+1 (305) 555-6120" autocomplete="tel">
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_percentage_allocation">Percentage Allocation</span>
-                    <input type="number" name="beneficiaryAllocation" value="100" min="0" max="100" step="1" required>
-                  </label>
-                  <label class="form-field">
-                    <span data-i18n-key="form_contact_method">Preferred Contact Method</span>
-                    <select name="beneficiaryContact">
-                      <option value="email" data-i18n-key="option_email">Email</option>
-                      <option value="phone" data-i18n-key="option_phone">Phone</option>
-                      <option value="text" data-i18n-key="option_sms">Text message</option>
-                    </select>
+                    <span>Phone</span>
+                    <input type="tel" name="beneficiaryPhone" value="+1 555-123-4567" autocomplete="tel">
                   </label>
                 </div>
+                <fieldset class="form-group">
+                  <legend>Address</legend>
+                  <label class="form-field">
+                    <span class="sr-only">Street Address</span>
+                    <input type="text" name="beneficiaryAddress1" value="123 Main Street" autocomplete="address-line1" required>
+                  </label>
+                  <label class="form-field">
+                    <span class="sr-only">Apartment, suite, etc.</span>
+                    <input type="text" name="beneficiaryAddress2" placeholder="Address Line 2" autocomplete="address-line2">
+                  </label>
+                  <div class="field-pair">
+                    <label class="form-field">
+                      <span class="sr-only">City</span>
+                      <input type="text" name="beneficiaryCity" value="Miami" autocomplete="address-level2" required>
+                    </label>
+                    <label class="form-field">
+                      <span class="sr-only">State</span>
+                      <select name="beneficiaryState" autocomplete="address-level1" required>
+                        <option value="" disabled>State</option>
+                        <option value="FL" selected>Florida</option>
+                        <option value="TX">Texas</option>
+                        <option value="CA">California</option>
+                        <option value="NY">New York</option>
+                      </select>
+                    </label>
+                  </div>
+                  <label class="form-field">
+                    <span class="sr-only">Postal Code</span>
+                    <input type="text" name="beneficiaryPostalCode" value="33101" autocomplete="postal-code">
+                  </label>
+                </fieldset>
                 <div class="form-actions">
-                  <button type="button" class="button ghost-button" data-action="cancel" data-i18n-key="button_cancel">Cancel</button>
-                  <button type="submit" class="button solid-button" data-i18n-key="button_save_beneficiary">Save Beneficiary</button>
+                  <button type="button" class="button cancel-button" data-action="cancel" data-i18n-key="button_cancel">Cancel</button>
+                  <button type="submit" class="button primary-button" data-i18n-key="button_save_beneficiary">Save Changes</button>
                 </div>
               </form>
-              <p class="member-since" data-i18n-key="profile_beneficiary_footnote">You can update your beneficiary any time before a claim is processed.</p>
             </section>
 
-            <section class="info-card documents-card">
-              <div class="card-header">
-                <div>
+            <section class="profile-panel documents-panel">
+              <div class="panel-header">
+                <div class="panel-copy">
                   <h2 data-i18n-key="profile_documents_title">Identification Documents</h2>
-                  <p data-i18n-key="profile_documents_subtitle">Upload current identification so we can verify your eligibility and beneficiary claims.</p>
+                  <p data-i18n-key="profile_documents_subtitle">Securely upload your ID's to keep your account verified and protected. Only one document is required for verification.</p>
                 </div>
               </div>
-              <form id="documentsForm" class="details-form documents-form">
-                <div class="document-item">
-                  <div class="document-info">
-                    <h3 data-i18n-key="doc_passport">Passport</h3>
-                    <p data-i18n-key="doc_passport_subtitle">Upload a clear scan of the picture page.</p>
-                    <p class="file-name" data-file-name="passportFile" data-i18n-key="placeholder_no_document">No document uploaded</p>
-                  </div>
-                  <div class="document-fields">
-                    <label class="form-field">
-                      <span data-i18n-key="form_status">Status</span>
-                      <select name="passportStatus" data-status-pill="passportStatus">
-                        <option value="uploaded" selected data-i18n-key="option_uploaded">Uploaded</option>
-                        <option value="expiring" data-i18n-key="option_expiring">Expiring Soon</option>
-                        <option value="pending" data-i18n-key="option_not_submitted">Not Submitted</option>
-                      </select>
-                    </label>
-                    <label class="file-upload">
-                      <input type="file" name="passportFile" data-file-output="passportFile" accept=".pdf,.jpg,.jpeg,.png" hidden>
-                      <span class="button outline-button" data-i18n-key="button_upload_replace">Upload / Replace Document</span>
-                    </label>
-                  </div>
-                  <div class="document-actions">
-                    <span class="status-pill status-success" data-status-pill-target="passportStatus" data-i18n-key="option_uploaded">Uploaded</span>
-                  </div>
+              <div class="documents-table">
+                <div class="documents-row">
+                  <span class="doc-title" data-i18n-key="doc_passport">Passport</span>
+                  <span class="status-badge status-uploaded">Uploaded</span>
+                  <button type="button" class="button doc-button">Upload/Update Document</button>
                 </div>
-
-                <div class="document-item">
-                  <div class="document-info">
-                    <h3 data-i18n-key="doc_drivers_license">Driver's License</h3>
-                    <p data-i18n-key="doc_drivers_license_subtitle">Ensure the address matches your current residence.</p>
-                    <p class="file-name" data-file-name="licenseFile" data-i18n-key="placeholder_no_document">No document uploaded</p>
-                  </div>
-                  <div class="document-fields">
-                    <label class="form-field">
-                      <span data-i18n-key="form_status">Status</span>
-                      <select name="licenseStatus" data-status-pill="licenseStatus">
-                        <option value="uploaded" data-i18n-key="option_uploaded">Uploaded</option>
-                        <option value="expiring" selected data-i18n-key="option_expiring">Expiring Soon</option>
-                        <option value="pending" data-i18n-key="option_not_submitted">Not Submitted</option>
-                      </select>
-                    </label>
-                    <label class="file-upload">
-                      <input type="file" name="licenseFile" data-file-output="licenseFile" accept=".pdf,.jpg,.jpeg,.png" hidden>
-                      <span class="button outline-button" data-i18n-key="button_upload_replace">Upload / Replace Document</span>
-                    </label>
-                  </div>
-                  <div class="document-actions">
-                    <span class="status-pill status-warning" data-status-pill-target="licenseStatus" data-i18n-key="option_expiring">Expiring Soon</span>
-                  </div>
+                <div class="documents-row">
+                  <span class="doc-title" data-i18n-key="doc_drivers_license">Driver's License</span>
+                  <span class="status-badge status-uploaded">Uploaded</span>
+                  <button type="button" class="button doc-button">Upload/Update Document</button>
                 </div>
-
-                <div class="document-item">
-                  <div class="document-info">
-                    <h3 data-i18n-key="doc_ssn">Social Security</h3>
-                    <p data-i18n-key="doc_ssn_subtitle">Required for beneficiary payouts and tax reporting.</p>
-                    <p class="file-name" data-file-name="ssnFile" data-i18n-key="placeholder_no_document">No document uploaded</p>
-                  </div>
-                  <div class="document-fields">
-                    <label class="form-field">
-                      <span data-i18n-key="form_status">Status</span>
-                      <select name="ssnStatus" data-status-pill="ssnStatus">
-                        <option value="uploaded" data-i18n-key="option_uploaded">Uploaded</option>
-                        <option value="expiring" data-i18n-key="option_expiring">Expiring Soon</option>
-                        <option value="pending" selected data-i18n-key="option_not_submitted">Not Submitted</option>
-                      </select>
-                    </label>
-                    <label class="file-upload">
-                      <input type="file" name="ssnFile" data-file-output="ssnFile" accept=".pdf,.jpg,.jpeg,.png" hidden>
-                      <span class="button outline-button" data-i18n-key="button_upload">Upload Document</span>
-                    </label>
-                  </div>
-                  <div class="document-actions">
-                    <span class="status-pill status-pending" data-status-pill-target="ssnStatus" data-i18n-key="option_not_submitted">Not Submitted</span>
-                  </div>
+                <div class="documents-row">
+                  <span class="doc-title" data-i18n-key="doc_ssn">Social Security</span>
+                  <span class="status-badge status-uploaded">Uploaded</span>
+                  <button type="button" class="button doc-button">Upload/Update Document</button>
                 </div>
-                <div class="form-actions">
-                  <button type="button" class="button ghost-button" data-action="cancel" data-i18n-key="button_cancel">Cancel</button>
-                  <button type="submit" class="button solid-button" data-i18n-key="button_save_documents">Save Documents</button>
-                </div>
-              </form>
+              </div>
             </section>
 
-            <section class="info-card language-card">
-              <div class="card-header">
-                <div>
+            <section class="profile-panel language-panel">
+              <div class="panel-header">
+                <div class="panel-copy">
                   <h2 data-i18n-key="profile_language_title">Language Preference</h2>
-                  <p data-i18n-key="profile_language_subtitle">Choose the language for emails, notifications, and support.</p>
+                  <p data-i18n-key="profile_language_subtitle">Choose the language you're most comfortable with.</p>
                 </div>
               </div>
-              <div class="language-body">
-                <div>
-                  <p data-i18n-key="profile_language_description">Your updates and care team messages will arrive in this language.</p>
-                  <label class="language-select" for="languageSelect">
-                    <span data-i18n-key="profile_language_label">Preferred language</span>
-                    <select id="languageSelect" name="languageSelect">
-                      <option value="en" data-i18n-key="lang_english">English</option>
-                      <option value="es" data-i18n-key="lang_spanish">Español</option>
-                      <option value="pt" data-i18n-key="lang_portuguese">Português</option>
-                    </select>
-                  </label>
-                </div>
-                <button type="button" class="button solid-button" id="updateLang" data-i18n-key="button_update_preference">Update Preference</button>
+              <div class="language-preference">
+                <label for="languageSelect" class="form-field">
+                  <span>Español</span>
+                  <select id="languageSelect" name="languageSelect">
+                    <option value="es" selected>Español</option>
+                    <option value="en">English</option>
+                    <option value="pt">Português</option>
+                  </select>
+                </label>
+                <button type="button" class="button primary-button" id="updateLang">Update Language</button>
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- rebuild the individual dashboard structure with sidebar navigation, hero welcome card, and refreshed content panels to match the provided mockup
- replace the previous profile panel styles with a golden palette and responsive layout rules tailored to the new HTML structure
- add an inline SVG fallback avatar asset used for the profile and hero sections when no user photo is supplied

## Testing
- not run (static HTML/CSS updates only)


------
https://chatgpt.com/codex/tasks/task_e_68dec19e72d48327a3df66b419f20a74