### PR TITLE
feat: Update language settings to remove Portuguese and set English a…

### DIFF
--- a/business-profile.html
+++ b/business-profile.html
@@ -158,7 +158,6 @@
             <div class="language-options" role="group" aria-label="Language preference">
               <button class="business-chip is-selected" type="button" data-language-option="en" data-i18n-key="lang_english">English</button>
               <button class="business-chip" type="button" data-language-option="es" data-i18n-key="lang_spanish">Español</button>
-              <button class="business-chip" type="button" data-language-option="pt" data-i18n-key="lang_portuguese">Português</button>
             </div>
             <p class="business-card__footnote" data-i18n-key="language_preference_footnote">Team notifications and billing reminders will use this language.</p>
           </article>
@@ -329,7 +328,6 @@
                   <select id="languageSelect" name="preferredLanguage">
                     <option value="en" selected>English (US)</option>
                     <option value="es">Español (LatAm)</option>
-                    <option value="pt">Português (Brasil)</option>
                   </select>
                 </label>
                 <label class="form-field">

--- a/business-profile.js
+++ b/business-profile.js
@@ -6,8 +6,7 @@ const STATUS_MAP = {
 
 const LANGUAGE_DATA = {
   en: { label: 'English (US)', button: 'English' },
-  es: { label: 'Español (LatAm)', button: 'Español' },
-  pt: { label: 'Português (Brasil)', button: 'Português' }
+  es: { label: 'Español (LatAm)', button: 'Español' }
 };
 
 const USER_TYPE_PREFIX = 'mallow-business-';

--- a/locales/en.json
+++ b/locales/en.json
@@ -299,7 +299,6 @@
   "language_preference_title": "Language Preference",
   "language_preference_subtitle": "Control how plan updates and onboarding resources appear for your team.",
   "primary_language_label": "Primary language:",
-  "lang_portuguese": "Português",
   "language_preference_footnote": "Team notifications and billing reminders will use this language.",
   "edit_details_title": "Edit details",
   "form_hq_street": "Headquarters street",

--- a/locales/es.json
+++ b/locales/es.json
@@ -299,7 +299,6 @@
   "language_preference_title": "Preferencia de Idioma",
   "language_preference_subtitle": "Controla cómo aparecen las actualizaciones del plan y los recursos de incorporación para tu equipo.",
   "primary_language_label": "Idioma principal:",
-  "lang_portuguese": "Português",
   "language_preference_footnote": "Las notificaciones del equipo y los recordatorios de facturación usarán este idioma.",
   "edit_details_title": "Editar detalles",
   "form_hq_street": "Calle de la sede",

--- a/my-profile.html
+++ b/my-profile.html
@@ -267,9 +267,8 @@
                 <label for="languageSelect" class="form-field">
                   <span>Español</span>
                   <select id="languageSelect" name="languageSelect">
-                    <option value="es" selected>Español</option>
-                    <option value="en">English</option>
-                    <option value="pt">Português</option>
+                    <option value="en" selected>English</option>
+                    <option value="es">Español</option>
                   </select>
                 </label>
                 <button type="button" class="button primary-button" id="updateLang">Update Language</button>


### PR DESCRIPTION
…s default

This commit updates the language settings across the site to make English the primary language, Spanish the secondary language, and removes the Portuguese option entirely.

- Removed the "Português" button and dropdown options from all relevant HTML files (`business-profile.html`, `my-profile.html`).
- Removed the Portuguese language data from the `LANGUAGE_DATA` object in `business-profile.js`.
- Removed the `lang_portuguese` translation key from the `locales/en.json` and `locales/es.json` files.
- Corrected the default selected language in `my-profile.html` to be English.