### PR TITLE
feat: Add user selection page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Select User Type</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="login.css">
+</head>
+<body>
+  <div class="login-wrapper">
+    <div class="login-form">
+      <div class="logo-circle">MC</div>
+      <h2>Select User Type</h2>
+      <div class="option-buttons">
+        <a class="btn primary" href="individual-login.html">Personal</a>
+        <a class="btn secondary" href="business-login.html">Business</a>
+      </div>
+    </div>
+    <div class="login-hero business">
+      <div class="content">
+        <h3>Human-centered benefits for your team.</h3>
+        <p>Offer your employees reliable and affordable funeral protections. A practical solution to enhance your company's benefit offering and support your team when they need it most.</p>
+      </div>
+    </div>
+  </div>
+  <script src="i18n.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This commit adds a new `index.html` file to serve as a simple user type selection page. This allows users to easily navigate to the appropriate login page for their account type (Personal or Business).

- Created `index.html` with a clear title and basic structure.
- Added two buttons: "Personal" linking to `individual-login.html` and "Business" linking to `business-login.html`.
- The page is styled using the existing `login.css` to ensure visual consistency with the rest of the site's login and signup pages.